### PR TITLE
MOBILE-1657: iOS: Change drawer to not animate out status bar

### DIFF
--- a/Example/WMobileKitExample/WMobileKitSideMenuVC.swift
+++ b/Example/WMobileKitExample/WMobileKitSideMenuVC.swift
@@ -19,9 +19,5 @@ class WMobileKitSideMenuVC: WSideMenuVC {
 class WMobileKitNVC: UINavigationController {
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // NOTE: Not sure why this doesn't work with the theme in the app delegate
-        let theme: WTheme = GreenTheme()
-        navigationBar.barTintColor = theme.navigationColor
     }
 }

--- a/Source/WSideMenuVC.swift
+++ b/Source/WSideMenuVC.swift
@@ -19,7 +19,6 @@ public struct WSideMenuOptions {
     // Default WSideMenu options, change before calling super.viewDidLoad()
     public var menuWidth = 300.0
     public var useBlur = true
-    // NOTE: Only works with solid color status bars with translucent = false
     public var showAboveStatusBar = true
     public var menuAnimationDuration = 0.3
     public var gesturesOpenSideMenu = true
@@ -43,7 +42,6 @@ public class WSideMenuVC: UIViewController {
     private var leftSideMenuContainerView = UIView(frame: CGRect.zero)
     private var mainContainerTapRecognizer: UITapGestureRecognizer?
     private var menuState: WSideMenuState = .Closed
-    private var statusBarView = UIView()
     private var statusBarHidden = false
 
     public required init?(coder aDecoder: NSCoder) {
@@ -74,27 +72,11 @@ public class WSideMenuVC: UIViewController {
 
         // Initial setup of views
         view.addSubview(mainContainerView)
-        view.insertSubview(leftSideMenuContainerView, aboveSubview: mainContainerView)
-
-        if options!.showAboveStatusBar {
-            view.insertSubview(statusBarView, belowSubview: leftSideMenuContainerView)
-
-            statusBarView.snp_makeConstraints { (make) in
-                make.left.equalTo(view)
-                make.right.equalTo(view)
-                make.height.equalTo(20)
-                make.top.equalTo(view)
-            }
-        }
+        view.addSubview(leftSideMenuContainerView)
 
         mainContainerView.snp_makeConstraints { (make) in
             make.left.equalTo(view)
-            if options!.showAboveStatusBar {
-                make.top.equalTo(statusBarView.snp_bottom)
-            } else {
-                make.top.equalTo(view)
-            }
-
+            make.top.equalTo(view)
             make.right.equalTo(view)
             make.bottom.equalTo(view)
         }
@@ -112,15 +94,7 @@ public class WSideMenuVC: UIViewController {
                                                                 action: #selector(WSideMenuVC.mainContainerViewWasTapped(_:)))
             mainContainerTapRecognizer?.enabled = false
             mainContainerView.addGestureRecognizer(mainContainerTapRecognizer!)
-            addViewControllerToContainer(mainContainerView, viewController: mainViewController)
-
-            if options!.showAboveStatusBar {
-                if let mainViewController = mainViewController as? UINavigationController {
-                    statusBarView.backgroundColor = mainViewController.navigationBar.barTintColor
-                } else {
-                    statusBarView.backgroundColor = mainViewController.view.backgroundColor
-                }
-            }
+            addViewControllerToContainer(mainContainerView, viewController: mainViewController)            
         }
 
         if let leftSideMenuViewController = leftSideMenuViewController {
@@ -150,27 +124,7 @@ public class WSideMenuVC: UIViewController {
         addViewControllerToContainer(mainContainerView, viewController: mainViewController)
         view.layoutIfNeeded()
     }
-
-    public override func preferredStatusBarUpdateAnimation() -> UIStatusBarAnimation {
-        if let options = options {
-            return options.showAboveStatusBar ? .Slide : .None
-        } else {
-            return .None
-        }
-    }
-
-    public override func prefersStatusBarHidden() -> Bool {
-        if let options = options {
-            if options.showAboveStatusBar {
-                return statusBarHidden
-            } else {
-                return false
-            }
-        } else {
-            return false
-        }
-    }
-
+    
     public override func preferredStatusBarStyle() -> UIStatusBarStyle {
         if let options = options {
             return options.statusBarStyle
@@ -207,11 +161,14 @@ public class WSideMenuVC: UIViewController {
         delegate?.sideMenuWillOpen?()
 
         statusBarHidden = !statusBarHidden
-
+        
+        if options!.showAboveStatusBar {
+            UIApplication.sharedApplication().delegate?.window!!.windowLevel = UIWindowLevelStatusBar
+        }
+        
         UIView.animateWithDuration(options!.menuAnimationDuration,
             animations: {
                 self.view.layoutIfNeeded()
-                self.setNeedsStatusBarAppearanceUpdate()
             },
             completion: { finished in
                 self.menuState = .Open
@@ -237,9 +194,12 @@ public class WSideMenuVC: UIViewController {
         UIView.animateWithDuration(options!.menuAnimationDuration,
             animations: {
                 self.view.layoutIfNeeded()
-                self.setNeedsStatusBarAppearanceUpdate()
             },
             completion: { finished in
+                if self.options!.showAboveStatusBar {
+                    UIApplication.sharedApplication().delegate?.window!!.windowLevel = UIWindowLevelNormal
+                }
+                
                 self.menuState = .Closed
                 self.delegate?.sideMenuDidClose?()
             }


### PR DESCRIPTION
## Description
- Currently the drawer component of our app will animate out the status bar when it opens and animate it back in when it closes. To achieve this, there is a view that is under the status bar. This view will no longer look correct with the background image that VxD wants.
## What Was Changed
- The status bar view and animation was removed from the `WSideMenuVC`.
- The status bar now hides and shows by changing the window location on the whole application.
- The theme specific to the navigation controller was removed.
## Testing
1. Ensure the drawer still works as is should.
2. Make sure the status bar hides when the drawer is open and shows when the drawer is closed.

---

Please Review: @Workiva/mobile  
