### PR TITLE
MOBILE-1682: Fixing side menu button adding bug

### DIFF
--- a/Source/WSideMenuVC.swift
+++ b/Source/WSideMenuVC.swift
@@ -249,8 +249,6 @@ public class WSideMenuContentVC: UIViewController, WSideMenuProtocol {
 
         // Needed for views to not show behind the nav bar
         UINavigationBar.appearance().translucent = false
-
-        addWSideMenuButtons()
     }
 
     public func addWSideMenuButtons() {
@@ -295,6 +293,8 @@ public class WSideMenuContentVC: UIViewController, WSideMenuProtocol {
 
         // Set the WSideMenu delegate when the VC appears
         sideMenuController()?.delegate = self
+        
+        addWSideMenuButtons()
     }
 
     public func toggleSideMenu() {


### PR DESCRIPTION
## Description
- Some of our view controllers are not getting the proper buttons added the them when subclassing the WSideMenuContentVC
## What Was Changed
- Moved the call to add the side buttons to `viewWillAppear` in the `w-mobile-kit` library.
- Added call to super in `viewWillAppear` for `WBaseFilesVC`. 
## Testing
1. Checkout `MOBILE-1682` in the `w-mobile-kit` submodule in the `wdesk-ios` repo.
2. Ensure the drawer button is added the top left for files, inbox, and tasks.
3. Ensure that when enter a folder, task detail, or notification detail has the drawer button and the back button.

---

Please Review: @Workiva/mobile  
