### PR TITLE
MOBILE-1603 - Autocomplete view improvements

### DIFF
--- a/Example/WMobileKitExample.xcodeproj/project.pbxproj
+++ b/Example/WMobileKitExample.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		73A12C6A1CBEC2DE0092A3C2 /* UserLogoViewExamplesVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A12C691CBEC2DE0092A3C2 /* UserLogoViewExamplesVC.swift */; };
 		73B2B5CE1CD2BB7000053D22 /* TextViewExamplesVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B2B5CD1CD2BB7000053D22 /* TextViewExamplesVC.swift */; };
 		80385E53D084ED5C70EE82DE /* Pods_WMobileKitExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3EBC53ABD49DE26032E3B06 /* Pods_WMobileKitExample.framework */; };
-		D50149E31CE3D90600E5263E /* AutoCompleteTextFieldExampleVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BE4C981CD94D4B0025E34E /* AutoCompleteTextFieldExampleVC.swift */; };
+		D50149E31CE3D90600E5263E /* AutoCompleteTextViewExampleVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BE4C981CD94D4B0025E34E /* AutoCompleteTextViewExampleVC.swift */; };
 		D50149E41CE3D90A00E5263E /* LoadingModalExamplesVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A022E81CCA8ACE00CC12E0 /* LoadingModalExamplesVC.swift */; };
 		D50149E51CE3D90D00E5263E /* SpinnerExamplesVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50149E11CE3C85D00E5263E /* SpinnerExamplesVC.swift */; };
 		D53D0BC01CAB11B70065D106 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53D0BB81CAB11B70065D106 /* AppDelegate.swift */; };
@@ -37,7 +37,7 @@
 		730364EA1CE4FFA600F8F3D8 /* SwitchAndRadioExamplesVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchAndRadioExamplesVC.swift; sourceTree = "<group>"; };
 		73A12C691CBEC2DE0092A3C2 /* UserLogoViewExamplesVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserLogoViewExamplesVC.swift; sourceTree = "<group>"; };
 		73B2B5CD1CD2BB7000053D22 /* TextViewExamplesVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextViewExamplesVC.swift; sourceTree = "<group>"; };
-		73BE4C981CD94D4B0025E34E /* AutoCompleteTextFieldExampleVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoCompleteTextFieldExampleVC.swift; sourceTree = "<group>"; };
+		73BE4C981CD94D4B0025E34E /* AutoCompleteTextViewExampleVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoCompleteTextViewExampleVC.swift; sourceTree = "<group>"; };
 		86294297CE93610FE8E6B978 /* Pods-WMobileKitExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WMobileKitExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-WMobileKitExample/Pods-WMobileKitExample.release.xcconfig"; sourceTree = "<group>"; };
 		8BFF613940B2D6813A6FAFE6 /* Pods-WMobileKitExample_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WMobileKitExample_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WMobileKitExample_Tests/Pods-WMobileKitExample_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		D3EBC53ABD49DE26032E3B06 /* Pods_WMobileKitExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WMobileKitExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -156,7 +156,7 @@
 				73B2B5CD1CD2BB7000053D22 /* TextViewExamplesVC.swift */,
 				D50149E11CE3C85D00E5263E /* SpinnerExamplesVC.swift */,
 				D7A022E81CCA8ACE00CC12E0 /* LoadingModalExamplesVC.swift */,
-				73BE4C981CD94D4B0025E34E /* AutoCompleteTextFieldExampleVC.swift */,
+				73BE4C981CD94D4B0025E34E /* AutoCompleteTextViewExampleVC.swift */,
 				730364EA1CE4FFA600F8F3D8 /* SwitchAndRadioExamplesVC.swift */,
 				D5F7A6531CF640F800636AB4 /* BadgeExamplesVC.swift */,
 			);
@@ -297,7 +297,7 @@
 				D5F7A6541CF640F800636AB4 /* BadgeExamplesVC.swift in Sources */,
 				D5A4F6151CB3305A0041BB98 /* PagingControlExamplesVC.swift in Sources */,
 				55A106331CAC8B5400495BBC /* LeftMenuTVCExample.swift in Sources */,
-				D50149E31CE3D90600E5263E /* AutoCompleteTextFieldExampleVC.swift in Sources */,
+				D50149E31CE3D90600E5263E /* AutoCompleteTextViewExampleVC.swift in Sources */,
 				D53D0BC51CAB11B70065D106 /* SideMenuVCExample.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/WMobileKitExample/AutoCompleteTextViewExampleVC.swift
+++ b/Example/WMobileKitExample/AutoCompleteTextViewExampleVC.swift
@@ -1,5 +1,5 @@
 //
-//  AutoFillTextFieldExampleVC.swift
+//  AutoFillTextViewExampleVC.swift
 //  WMobileKitExample
 //
 //  Copyright 2016 Workiva Inc.
@@ -21,35 +21,35 @@ import WMobileKit
 
 let autoCellIdentifier = "autoCompleteCell"
 
-public class AutoCompleteTextFieldExampleVC: WSideMenuContentVC {
+public class AutoCompleteTextViewExampleVC: WSideMenuContentVC {
     public var searchResults = [String]()
-    public var textView = WAutoCompleteTextView()
+    public var autoCompleteView = WAutoCompleteTextView()
     
     public override func viewDidLoad() {
         super.viewDidLoad()
         
         // These values are not set by default, must be set for full functionality
-        textView.controlPrefix = "@"
-        textView.dataSource = self
-        textView.delegate = self
-        textView.autoCompleteTable.registerClass(UITableViewCell.self, forCellReuseIdentifier: autoCellIdentifier)
+        autoCompleteView.controlPrefix = "@"
+        autoCompleteView.dataSource = self
+        autoCompleteView.delegate = self
+        autoCompleteView.autoCompleteTable.registerClass(UITableViewCell.self, forCellReuseIdentifier: autoCellIdentifier)
         
         // These values have defaults, but are set differently for the example
-        textView.autoCompleteTable.rowHeight = 40
-        textView.maxAutoCompleteHeight = 130
+        autoCompleteView.autoCompleteTable.rowHeight = 40
+        autoCompleteView.maxAutoCompleteHeight = 130
         
         // These values are already set by default, shown here for the example
-        textView.addSpaceAfterReplacement = true
-        textView.replacesControlPrefix = false
-        textView.numCharactersBeforeAutoComplete = 1
+        autoCompleteView.addSpaceAfterReplacement = true
+        autoCompleteView.replacesControlPrefix = false
+        autoCompleteView.numCharactersBeforeAutoComplete = 1
         
-        view.addSubview(textView)
+        view.addSubview(autoCompleteView)
     }
 }
 
 // MARK: Table View Data Source
 //       Must be implemented for auto completion
-extension AutoCompleteTextFieldExampleVC: WAutoCompleteTextViewDataSource {
+extension AutoCompleteTextViewExampleVC: WAutoCompleteTextViewDataSource {
     public func heightForAutoCompleteTable(textView: WAutoCompleteTextView) -> CGFloat {
         return CGFloat(searchResults.count * 40)
     }
@@ -61,10 +61,11 @@ extension AutoCompleteTextFieldExampleVC: WAutoCompleteTextViewDataSource {
         for i in 1...4 {
             searchResults.append(word.stringByAppendingString(String(i)))
         }
+        autoCompleteView.showAutoCompleteTable()
     }
 }
 
-extension AutoCompleteTextFieldExampleVC: UITableViewDataSource {
+extension AutoCompleteTextViewExampleVC: UITableViewDataSource {
     public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         // Auto completion cells show data from search results
         let cell = tableView.dequeueReusableCellWithIdentifier(autoCellIdentifier)!
@@ -83,7 +84,7 @@ extension AutoCompleteTextFieldExampleVC: UITableViewDataSource {
 
 // MARK: Auto Complete Text View Delegate
 //       Must be implemented for auto completion
-extension AutoCompleteTextFieldExampleVC: WAutoCompleteTextViewDelegate {
+extension AutoCompleteTextViewExampleVC: WAutoCompletionTextViewDelegate {
     public func didSelectAutoCompletion(data: AnyObject) {
         // Word was chosen, called after word has been replaced
     }

--- a/Example/WMobileKitExample/Base.lproj/Main.storyboard
+++ b/Example/WMobileKitExample/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -630,7 +630,7 @@
         <!--NavigationVC-->
         <scene sceneID="iKe-Y1-geA">
             <objects>
-                <navigationController storyboardIdentifier="AutoCompleteTextFieldExampleVC" id="Fkx-XM-Urm" customClass="NavigationVC" customModule="WMobileKitExample_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="AutoCompleteTextViewExampleVC" id="Fkx-XM-Urm" customClass="NavigationVC" customModule="WMobileKitExample_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="I5e-CN-gkp">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -643,10 +643,10 @@
             </objects>
             <point key="canvasLocation" x="1159" y="7658"/>
         </scene>
-        <!--Auto Complete Text Field ExampleVC-->
+        <!--Auto Complete Text View ExampleVC-->
         <scene sceneID="r9Y-9w-xI6">
             <objects>
-                <viewController id="fCc-Wf-TOc" customClass="AutoCompleteTextFieldExampleVC" customModule="WMobileKitExample_Example" sceneMemberID="viewController">
+                <viewController id="fCc-Wf-TOc" customClass="AutoCompleteTextViewExampleVC" customModule="WMobileKitExample_Example" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="sAN-g7-aFl"/>
                         <viewControllerLayoutGuide type="bottom" id="1QC-NJ-G1w"/>
@@ -926,7 +926,7 @@
                                     <constraint firstAttribute="width" constant="80" id="ufY-sl-0KS"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -1006,7 +1006,7 @@
                                     <constraint firstAttribute="width" constant="256" id="fZc-Hn-GQn"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="31"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Reusable, custom swift UI components" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JsT-1r-jNK">
@@ -1026,7 +1026,7 @@
                                     <constraint firstAttribute="height" constant="30" id="hvj-o7-0ai"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="23"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Press the top left icon to view examples" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pZJ-Vm-OxB">

--- a/Example/WMobileKitExample/LeftMenuTVCExample.swift
+++ b/Example/WMobileKitExample/LeftMenuTVCExample.swift
@@ -36,7 +36,7 @@ class LeftMenuTVCExample: UITableViewController {
     lazy var textViewExamplesVC: NavigationVC = mainStoryboard.instantiateViewControllerWithIdentifier("TextViewExamplesVC") as! NavigationVC
     lazy var spinnerExamplesVC: NavigationVC = mainStoryboard.instantiateViewControllerWithIdentifier("SpinnerExamplesVC") as! NavigationVC
     lazy var loadingModalExamplesVC: NavigationVC = mainStoryboard.instantiateViewControllerWithIdentifier("LoadingModalExamplesVC") as! NavigationVC
-    lazy var autoCompleteTextFieldExampleVC: NavigationVC = mainStoryboard.instantiateViewControllerWithIdentifier("AutoCompleteTextFieldExampleVC") as! NavigationVC
+    lazy var autoCompleteTextViewExampleVC: NavigationVC = mainStoryboard.instantiateViewControllerWithIdentifier("AutoCompleteTextViewExampleVC") as! NavigationVC
     lazy var switchAndRadioExamplesVC: NavigationVC = mainStoryboard.instantiateViewControllerWithIdentifier("SwitchAndRadioExamplesVC") as! NavigationVC
     lazy var badgeExamplesVC: NavigationVC = mainStoryboard.instantiateViewControllerWithIdentifier("BadgeExamplesVC") as! NavigationVC
 
@@ -88,7 +88,7 @@ class LeftMenuTVCExample: UITableViewController {
         case 8:
             sideMenuController()?.changeMainViewController(loadingModalExamplesVC)
         case 9:
-            sideMenuController()?.changeMainViewController(autoCompleteTextFieldExampleVC)
+            sideMenuController()?.changeMainViewController(autoCompleteTextViewExampleVC)
         case 10:
             sideMenuController()?.changeMainViewController(switchAndRadioExamplesVC)
         case 11:

--- a/Source/WAutoCompleteTextView.swift
+++ b/Source/WAutoCompleteTextView.swift
@@ -223,9 +223,7 @@ public class WAutoCompleteTextView : UIView {
             autoCompleteTable.reloadData()
         }
 
-        if (show && !isAutoCompleting) {
-            animateTable(show)
-        } else if (!show && isAutoCompleting) {
+        if ( (show && !isAutoCompleting) || (!show && isAutoCompleting) ) {
             animateTable(show)
         }
     }
@@ -245,7 +243,7 @@ public class WAutoCompleteTextView : UIView {
                 isAutoCompleting = false
             }
         }
-                
+        
         UIView.animateWithDuration(0.3,
             animations: {
                 self.updateHeight()
@@ -343,7 +341,7 @@ extension WAutoCompleteTextView : UITextViewDelegate {
     }
     
     private func updateHeight() {
-        if let currentSuperview = superview {
+        if (superview != nil) {
             if (textView.contentSize.height > 0) {
                 var height = min(textView.contentSize.height, MAX_TEXT_VIEW_HEIGHT)
                 height = max(height, TEXT_VIEW_HEIGHT)

--- a/Source/WTextView.swift
+++ b/Source/WTextView.swift
@@ -31,6 +31,7 @@ public class WTextView: UITextView, UITextViewDelegate {
     override public var text: String! {
         didSet {
             textDidChange()
+            buildTextView(text)
         }
     }
         

--- a/Tests/WAutoCompleteTextViewTests.swift
+++ b/Tests/WAutoCompleteTextViewTests.swift
@@ -1,8 +1,8 @@
 //
-//  WAutoCompleteTextFieldTests.swift
+//  WAutoCompleteTextViewTests.swift
 //  WMobileKit
 //
-//  Code coverage at 81% due to issue with UITextField not getting a beginningOfDocument property
+//  Code coverage at 81% due to issue with UITextView not getting a beginningOfDocument property
 //  set when setting its text manually, and thus not being able to access a selectedTextRange
 //
 //  Copyright 2016 Workiva Inc.
@@ -24,18 +24,18 @@ import Quick
 import Nimble
 @testable import WMobileKit
 
-class WAutoCompleteTextFieldSpec: QuickSpec {
+class WAutoCompleteTextViewSpec: QuickSpec {
     override func spec() {
-        describe("WAutoCompleteTextFieldSpec") {
+        describe("WAutoCompleteTextViewSpec") {
             var subject: AutoCompleteTestViewController!
             var window: UIWindow!
-            var textView: WAutoCompleteTextView!
+            var autoCompleteView: WAutoCompleteTextView!
             
             beforeEach({
                 subject = AutoCompleteTestViewController()
-                textView = WAutoCompleteTextView()
-                textView.delegate = subject
-                textView.dataSource = subject
+                autoCompleteView = WAutoCompleteTextView()
+                autoCompleteView.delegate = subject
+                autoCompleteView.dataSource = subject
                 
                 window = UIWindow(frame: UIScreen.mainScreen().bounds)
                 window.rootViewController = subject
@@ -45,24 +45,24 @@ class WAutoCompleteTextFieldSpec: QuickSpec {
             })
             
             afterEach({
-                if textView != nil {
-                    textView.removeFromSuperview()
+                if autoCompleteView != nil {
+                    autoCompleteView.removeFromSuperview()
                 }
-                textView = nil
+                autoCompleteView = nil
             })
             
             describe("when app has been init") {
                 let verifyCommonInit = {
-                    expect(textView.numCharactersBeforeAutoComplete) == 1
-                    expect(textView.addSpaceAfterReplacement) == true
-                    expect(textView.replacesControlPrefix) == false
+                    expect(autoCompleteView.numCharactersBeforeAutoComplete) == 1
+                    expect(autoCompleteView.addSpaceAfterReplacement) == true
+                    expect(autoCompleteView.replacesControlPrefix) == false
                 }
 
                 it("should init with coder correctly") {
                     let path = NSTemporaryDirectory() as NSString
                     let locToSave = path.stringByAppendingPathComponent("WAutoCompleteTextView")
                     
-                    NSKeyedArchiver.archiveRootObject(textView, toFile: locToSave)
+                    NSKeyedArchiver.archiveRootObject(autoCompleteView, toFile: locToSave)
                     
                     let object = NSKeyedUnarchiver.unarchiveObjectWithFile(locToSave) as! WAutoCompleteTextView
                     
@@ -73,35 +73,35 @@ class WAutoCompleteTextFieldSpec: QuickSpec {
                 }
                 
                 it("should fit the superview it is added to") {
-                    subject.view.addSubview(textView)
+                    subject.view.addSubview(autoCompleteView)
                     
-                    expect(textView.bounds.width).to(equal(subject.view.bounds.width))
+                    expect(autoCompleteView.bounds.width).to(equal(subject.view.bounds.width))
                 }
                 
                 it("should have properties set properly") {
-                    subject.view.addSubview(textView)
+                    subject.view.addSubview(autoCompleteView)
                     
-                    textView.rowHeight = 50
-                    textView.maxAutoCompleteHeight = 150
-                    textView.showAutoCompleteView()
+                    autoCompleteView.rowHeight = 50
+                    autoCompleteView.maxAutoCompleteHeight = 150
+                    autoCompleteView.showAutoCompleteTable()
                     
-                    expect(textView.autoCompleteTable.frame.size.height).toEventually(equal(100), timeout: 0.3)
+                    expect(autoCompleteView.isShowingAutoComplete()).toEventually(equal(true), timeout: 0.3)
                 }
                 
                 it("should have properties set properly without delegate") {
-                    textView = WAutoCompleteTextView()
+                    autoCompleteView = WAutoCompleteTextView()
                     
-                    textView.rowHeight = 50
-                    textView.maxAutoCompleteHeight = 150
-                    textView.showAutoCompleteView()
+                    autoCompleteView.rowHeight = 50
+                    autoCompleteView.maxAutoCompleteHeight = 150
+                    autoCompleteView.showAutoCompleteTable()
                     
-                    expect(textView.autoCompleteTable.frame.size.height).toEventually(equal(150), timeout: 0.3)
+                    expect(autoCompleteView.isShowingAutoComplete()).toEventually(equal(true), timeout: 0.3)
                 }
             }
             
             describe("notifications") {
                 it("should receive notification when keyboard will show") {
-                    subject.view.addSubview(textView)
+                    subject.view.addSubview(autoCompleteView)
                     
                     let userInfo: [NSObject: AnyObject] = [UIKeyboardFrameEndUserInfoKey: NSValue(CGRect: CGRect(x: 0, y: 0, width: 10, height: 10))]
                     let notification = NSNotification(name: UIKeyboardWillShowNotification, object: nil, userInfo: userInfo)
@@ -110,15 +110,15 @@ class WAutoCompleteTextFieldSpec: QuickSpec {
                 }
                 
                 it("should set view to bottom when keyboard will hide") {
-                    subject.view.addSubview(textView)
+                    subject.view.addSubview(autoCompleteView)
                     
                     NSNotificationCenter.defaultCenter().postNotificationName(UIKeyboardWillHideNotification, object: nil)
                     
-                    expect(textView.frame.origin.y).toEventually(equal(textView.superview!.frame.size.height - textView.frame.size.height), timeout: 0.3)
+                    expect(autoCompleteView.frame.origin.y).toEventually(equal(autoCompleteView.superview!.frame.size.height - autoCompleteView.frame.size.height), timeout: 0.3)
                 }
                 
                 it("should remove as observer when deinit") {
-                    textView = nil
+                    autoCompleteView = nil
                     
                     NSNotificationCenter.defaultCenter().postNotificationName(UIKeyboardWillHideNotification, object: nil)
                 }
@@ -126,105 +126,106 @@ class WAutoCompleteTextFieldSpec: QuickSpec {
             
             describe("auto complete") {
                 it("should show table correctly") {
-                    textView.showAutoCompleteView()
-                    
-                    expect(textView.autoCompleteTable.hidden) == false
+                    expect(autoCompleteView.isShowingAutoComplete()) == false
+                    autoCompleteView.showAutoCompleteTable()
+                    expect(autoCompleteView.isShowingAutoComplete()).toEventually(equal(true), timeout: 0.3)
                 }
                 
                 it("should hide table correctly") {
-                    textView.showAutoCompleteView(false)
-                    
-                    expect(textView.autoCompleteTable.hidden).toEventually(beTrue(), timeout: 0.3)
+                    expect(autoCompleteView.isShowingAutoComplete()) == false
+                    autoCompleteView.showAutoCompleteTable()
+                    expect(autoCompleteView.isShowingAutoComplete()).toEventually(equal(true), timeout: 0.3)
+                    autoCompleteView.showAutoCompleteTable(false)
+                    expect(autoCompleteView.isShowingAutoComplete()).toEventually(equal(false), timeout: 0.3)
                 }
                 
                 // Unable to test both processWordAtCursor and wordRangeAtCursor due to
-                //   iOS bug not setting .beginningOfDocument when setting text manually on UITextField
+                //   iOS bug not setting .beginningOfDocument when setting text manually on UITextView
                 it("should show auto complete table if prefix is typed with min num of following chars") {
-                    subject.view.addSubview(textView)
-                    textView.controlPrefix = "@"
+                    subject.view.addSubview(autoCompleteView)
+                    autoCompleteView.controlPrefix = "@"
                     
-                    let textField = textView.textField
-                    textField.text = "@test"
+                    let textView = autoCompleteView.textView
+                    textView.text = "@test"
                     
-                    let range = textField.textRangeFromPosition(textField.beginningOfDocument, toPosition: textField.endOfDocument)
-                    textField.selectedTextRange = range
+                    let range = textView.textRangeFromPosition(textView.beginningOfDocument, toPosition: textView.endOfDocument)
+                    textView.selectedTextRange = range
                     
-                    textView.textFieldDidChange(textField)
-                    
-//                    expect(textView.autoCompleteTable.hidden) == false
+                    autoCompleteView.textViewDidChange(textView)
+                    //expect(autoCompleteView.isShowingAutoComplete()).toEventually(equal(true), timeout: 0.3)
                 }
                 
                 it("should replace auto completions correctly") {
                     let initialText = "Unit testing @a"
                     let finalText = "Unit testing @auto completion "
-                    textView.textField.text = initialText
+                    autoCompleteView.textView.text = initialText
                     let range = initialText.rangeOfString("@a")
-                    textView.autoCompleteRange = range
+                    autoCompleteView.autoCompleteRange = range
                     
-                    textView.acceptAutoCompletionWithString("auto completion")
+                    autoCompleteView.acceptAutoCompletionWithString("auto completion")
                     
-                    expect(textView.textField.text).to(equal(finalText))
+                    expect(autoCompleteView.textView.text).to(equal(finalText))
                 }
                 
                 it("should replace auto completions correctly in middle of string") {
-                    textView.addSpaceAfterReplacement = false
+                    autoCompleteView.addSpaceAfterReplacement = false
                     let initialText = "Unit testing @a completion"
                     let finalText = "Unit testing @auto completion"
-                    textView.textField.text = initialText
+                    autoCompleteView.textView.text = initialText
                     let range = initialText.rangeOfString("@a")
-                    textView.autoCompleteRange = range
+                    autoCompleteView.autoCompleteRange = range
                     
-                    textView.acceptAutoCompletionWithString("auto")
+                    autoCompleteView.acceptAutoCompletionWithString("auto")
                     
-                    expect(textView.textField.text).to(equal(finalText))
+                    expect(autoCompleteView.textView.text).to(equal(finalText))
                 }
                 
                 it("should replace auto completions correctly with overriding prefix") {
-                    textView.addSpaceAfterReplacement = false
-                    textView.replacesControlPrefix = true
+                    autoCompleteView.addSpaceAfterReplacement = false
+                    autoCompleteView.replacesControlPrefix = true
                     let initialText = "Unit testing @a"
                     let finalText = "Unit testing auto completion"
-                    textView.textField.text = initialText
+                    autoCompleteView.textView.text = initialText
                     let range = initialText.rangeOfString("@a")
-                    textView.autoCompleteRange = range
+                    autoCompleteView.autoCompleteRange = range
                     
-                    textView.acceptAutoCompletionWithString("auto completion")
+                    autoCompleteView.acceptAutoCompletionWithString("auto completion")
                     
-                    expect(textView.textField.text).to(equal(finalText))
+                    expect(autoCompleteView.textView.text).to(equal(finalText))
                 }
                 
                 it("should dismiss auto complete when table cell is selected") {
-                    textView.autoCompleteTable.reloadData()
-                    textView.tableView(textView.autoCompleteTable, didSelectRowAtIndexPath: NSIndexPath(forRow: 0, inSection: 0))
-                    textView.showAutoCompleteView()
+                    autoCompleteView.autoCompleteTable.reloadData()
+                    autoCompleteView.showAutoCompleteTable()
+                    autoCompleteView.tableView(autoCompleteView.autoCompleteTable, didSelectRowAtIndexPath: NSIndexPath(forRow: 0, inSection: 0))
                     
-                    expect(textView.autoCompleteTable.hidden).toEventually(equal(true), timeout: 0.3)
+                    expect(autoCompleteView.isShowingAutoComplete()).toEventually(equal(false), timeout: 0.3)
                 }
                 
-                it("should dismiss auto complete when text field is done editing") {
-                    textView.showAutoCompleteView()
-                    textView.textFieldDidEndEditing(textView.textField)
+                it("should dismiss auto complete when text view is done editing") {
+                    autoCompleteView.showAutoCompleteTable()
+                    autoCompleteView.textViewDidEndEditing(autoCompleteView.textView)
                     
-                    expect(textView.autoCompleteTable.hidden).toEventually(equal(true), timeout: 0.3)
+                    expect(autoCompleteView.isShowingAutoComplete()).toEventually(equal(false), timeout: 0.3)
                 }
                 
                 it("should dismiss auto complete if auto complete is up and there is no selection") {
-                    textView.showAutoCompleteView()
+                    autoCompleteView.showAutoCompleteTable()
                     
-                    textView.processWordAtCursor(textView.textField)
+                    autoCompleteView.processWordAtCursor(autoCompleteView.textView)
                     
-                    expect(textView.autoCompleteTable.hidden).toEventually(beTrue(), timeout: 0.3)
+                    expect(autoCompleteView.isShowingAutoComplete()).toEventually(equal(false), timeout: 0.3)
                 }
                 
                 it("should return nil for word range at cursor if text is empty") {
-                    expect(textView.wordRangeAtCursor(textView.textField)).to(beNil())
+                    expect(autoCompleteView.wordRangeAtCursor(autoCompleteView.textView)).to(beNil())
                 }
             }
         }
     }
 }
 
-class AutoCompleteTestViewController: UIViewController, WAutoCompleteTextViewDelegate, WAutoCompleteTextViewDataSource, UITableViewDataSource {
+class AutoCompleteTestViewController: UIViewController, WAutoCompletionTextViewDelegate, WAutoCompleteTextViewDataSource, UITableViewDataSource {
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 2
     }

--- a/WMobileKit.xcodeproj/project.pbxproj
+++ b/WMobileKit.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		73A12C6F1CC0102A0092A3C2 /* WActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A12C6E1CC0102A0092A3C2 /* WActionSheet.swift */; };
 		73B2B5CA1CD2B1D500053D22 /* WTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B2B5C91CD2B1D500053D22 /* WTextViewTests.swift */; };
 		73B2B5CC1CD2B5AA00053D22 /* WTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B2B5CB1CD2B5AA00053D22 /* WTextView.swift */; };
-		73B81F191CE13A62009A9D73 /* WAutoCompleteTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B81F181CE13A62009A9D73 /* WAutoCompleteTextFieldTests.swift */; };
+		73B81F191CE13A62009A9D73 /* WAutoCompleteTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B81F181CE13A62009A9D73 /* WAutoCompleteTextViewTests.swift */; };
 		73B81F1C1CE13DA1009A9D73 /* WAutoCompleteTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B81F1A1CE13D12009A9D73 /* WAutoCompleteTextView.swift */; };
 		99377122C922B8D426C0F92C /* Pods_WMobileKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9014B7182CFF6FADD5EC6054 /* Pods_WMobileKitTests.framework */; };
 		D51201BA1CC17F7C0000FC95 /* UIAppearance+SwiftTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D51201B91CC17F7C0000FC95 /* UIAppearance+SwiftTests.m */; };
@@ -81,7 +81,7 @@
 		73A12C6E1CC0102A0092A3C2 /* WActionSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WActionSheet.swift; sourceTree = "<group>"; };
 		73B2B5C91CD2B1D500053D22 /* WTextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WTextViewTests.swift; sourceTree = "<group>"; };
 		73B2B5CB1CD2B5AA00053D22 /* WTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WTextView.swift; sourceTree = "<group>"; };
-		73B81F181CE13A62009A9D73 /* WAutoCompleteTextFieldTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WAutoCompleteTextFieldTests.swift; sourceTree = "<group>"; };
+		73B81F181CE13A62009A9D73 /* WAutoCompleteTextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WAutoCompleteTextViewTests.swift; sourceTree = "<group>"; };
 		73B81F1A1CE13D12009A9D73 /* WAutoCompleteTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WAutoCompleteTextView.swift; sourceTree = "<group>"; };
 		9014B7182CFF6FADD5EC6054 /* Pods_WMobileKitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WMobileKitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA23B86A117BB8C881149924 /* Pods_WMobileKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WMobileKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -238,7 +238,7 @@
 				D51201B91CC17F7C0000FC95 /* UIAppearance+SwiftTests.m */,
 				D518B1DA1CDC08D20058B6A9 /* WExtensionsTests.swift */,
 				73A12C6B1CC00F970092A3C2 /* WActionSheetTests.swift */,
-				73B81F181CE13A62009A9D73 /* WAutoCompleteTextFieldTests.swift */,
+				73B81F181CE13A62009A9D73 /* WAutoCompleteTextViewTests.swift */,
 				D5409CE91CCFD07200F984D3 /* WBannerTests.swift */,
 				D56DF0181CF8F5A4000893C1 /* WBadgeTests.swift */,
 				D71E55DD1CECBC7D00A7D1CB /* WCustomTransitionsTests.swift */,
@@ -518,7 +518,7 @@
 				D71E55DE1CECBC7D00A7D1CB /* WCustomTransitionsTests.swift in Sources */,
 				D53356CB1CBD6ACC00D9A6A9 /* WPagingSelectorVCTests.swift in Sources */,
 				D5409CEA1CCFD07200F984D3 /* WBannerTests.swift in Sources */,
-				73B81F191CE13A62009A9D73 /* WAutoCompleteTextFieldTests.swift in Sources */,
+				73B81F191CE13A62009A9D73 /* WAutoCompleteTextViewTests.swift in Sources */,
 				D7CC99A41CC9614B00572B6F /* WSpinnerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## Description

Improvements to the autocomplete view to support features needed.
## What Was Changed
- Refactored `WAutoCompleteTextView` to use a `UITextView` instead of a `UITextField`
- Added the ability to have a submit button
- Added placeholder text support to `WTextView`
## Testing

Can be tested via [this app ticket](https://github.com/Workiva/wdesk-ios/pull/995).

---

Please Review: @Workiva/mobile  
