### PR TITLE
MOBILE-1774: Drawer should act as a modal when open 

### DIFF
--- a/Source/WSideMenuVC.swift
+++ b/Source/WSideMenuVC.swift
@@ -50,14 +50,15 @@ public class WSideMenuVC: UIViewController {
     // Setable properties
     public var mainViewController: UIViewController?
     public var leftSideMenuViewController: UIViewController?
+    public var backgroundView: UIView!
     public var options: WSideMenuOptions?
     public weak var delegate: WSideMenuProtocol?
 
     // Internal properties
-    var mainContainerView = UIView(frame: CGRect.zero)
-    var leftSideMenuContainerView = UIView(frame: CGRect.zero)
+    var backgroundTapView = UIView()
+    var mainContainerView = UIView()
+    var leftSideMenuContainerView = UIView()
     var leftSideMenuBorderView = UIView()
-    var mainContainerTapRecognizer: UITapGestureRecognizer?
     var menuState: WSideMenuState = .Closed
     var statusBarHidden = false
 
@@ -92,9 +93,20 @@ public class WSideMenuVC: UIViewController {
 
         // Initial setup of views
         view.addSubview(mainContainerView)
+
+        // Add background tap view behind the side menu
+        view.insertSubview(backgroundTapView, aboveSubview: mainContainerView)
+
         view.addSubview(leftSideMenuContainerView)
 
         mainContainerView.snp_makeConstraints { (make) in
+            make.left.equalTo(view)
+            make.top.equalTo(view)
+            make.right.equalTo(view)
+            make.bottom.equalTo(view)
+        }
+
+        backgroundTapView.snp_makeConstraints { (make) in
             make.left.equalTo(view)
             make.top.equalTo(view)
             make.right.equalTo(view)
@@ -108,12 +120,12 @@ public class WSideMenuVC: UIViewController {
         }
 
         if let mainViewController = mainViewController {
-            // Add a tap gesture recongizer to the mainContainerView
+            // Add a tap gesture recongizer to the backgroundTapView
             // When the side menu is open, allow it to be tapped to close it
-            mainContainerTapRecognizer = UITapGestureRecognizer(target: self,
-                                                                action: #selector(WSideMenuVC.mainContainerViewWasTapped(_:)))
-            mainContainerTapRecognizer?.enabled = false
-            mainContainerView.addGestureRecognizer(mainContainerTapRecognizer!)
+            let backgroundTapRecognizer = UITapGestureRecognizer(target: self,
+                                                                 action: #selector(WSideMenuVC.backgroundWasTapped(_:)))
+            backgroundTapView.hidden = true
+            backgroundTapView.addGestureRecognizer(backgroundTapRecognizer)
 
             addViewControllerToContainer(mainContainerView, viewController: mainViewController)
             
@@ -191,7 +203,7 @@ public class WSideMenuVC: UIViewController {
         }
 
         // Enable the tap outside the drawer to close on when side menu is open
-        mainContainerTapRecognizer?.enabled = true
+        backgroundTapView.hidden = false
 
         leftSideMenuContainerView.snp_remakeConstraints { (make) in
             make.height.equalTo(view)
@@ -221,7 +233,7 @@ public class WSideMenuVC: UIViewController {
 
     public func closeSideMenu() {
         // Disable the tap outside the drawer to close
-        mainContainerTapRecognizer?.enabled = false
+        backgroundTapView.hidden = true
 
         leftSideMenuContainerView.snp_remakeConstraints { (make) in
             make.height.equalTo(view)
@@ -250,7 +262,7 @@ public class WSideMenuVC: UIViewController {
     }
 
     @objc
-    func mainContainerViewWasTapped(sender: AnyObject) {
+    func backgroundWasTapped(sender: AnyObject) {
         closeSideMenu()
     }
 }

--- a/Tests/WSideMenuVCTests.swift
+++ b/Tests/WSideMenuVCTests.swift
@@ -96,18 +96,21 @@ class WSideMenuVCSpec: QuickSpec {
 
                     expect(subject.menuState).toEventually(equal(WSideMenuState.Open), timeout: 1)
                     expect(subject.statusBarHidden).to(beTruthy())
+                    expect(subject.backgroundTapView.hidden) == false
 
                     // Close
                     subject.toggleSideMenu()
 
                     expect(subject.menuState).toEventually(equal(WSideMenuState.Closed), timeout: 1)
                     expect(subject.statusBarHidden).to(beFalsy())
+                    expect(subject.backgroundTapView.hidden) == true
 
                     // Open
                     subject.toggleSideMenu()
 
                     expect(subject.menuState).toEventually(equal(WSideMenuState.Open), timeout: 1)
                     expect(subject.statusBarHidden).to(beTruthy())
+                    expect(subject.backgroundTapView.hidden) == false
                 }
             }
 
@@ -161,12 +164,14 @@ class WSideMenuVCSpec: QuickSpec {
 
                     expect(subject.menuState).toEventually(equal(WSideMenuState.Open), timeout: 1)
                     expect(subject.statusBarHidden).to(beTruthy())
+                    expect(subject.backgroundTapView.hidden) == false
 
-                    subject.mainContainerViewWasTapped(subject)
+                    subject.backgroundWasTapped(subject)
 
                     // Now closed
                     expect(subject.menuState).toEventually(equal(WSideMenuState.Closed), timeout: 1)
                     expect(subject.statusBarHidden).to(beFalsy())
+                    expect(subject.backgroundTapView.hidden) == true
                 }
             }
 
@@ -189,18 +194,21 @@ class WSideMenuVCSpec: QuickSpec {
 
                     expect(subject.menuState).toEventually(equal(WSideMenuState.Open), timeout: 1)
                     expect(subject.statusBarHidden).to(beTruthy())
+                    expect(subject.backgroundTapView.hidden) == false
 
                     // Close
                     sideMenuContentVC.toggleSideMenu()
 
                     expect(subject.menuState).toEventually(equal(WSideMenuState.Closed), timeout: 1)
                     expect(subject.statusBarHidden).to(beFalsy())
+                    expect(subject.backgroundTapView.hidden) == true
 
                     // Open
                     sideMenuContentVC.toggleSideMenu()
 
                     expect(subject.menuState).toEventually(equal(WSideMenuState.Open), timeout: 1)
                     expect(subject.statusBarHidden).to(beTruthy())
+                    expect(subject.backgroundTapView.hidden) == false
                 }
 
                 it("should respond to the back button item being tapped") {


### PR DESCRIPTION
## Description

While the drawer is open, tapping anywhere outside the drawer should close the drawer. It should act as a modal. 

If the drawer is open, the item you tapped on in the background (e.g. the overflow/elipses icon) should not trigger until the second time you tap it (after the drawer has closed). The first time you tap it, the drawer should close (and that's it). Tapping on it a second time with the drawer closed would activate the action sheet, for example.
## What Was Changed
- Added a new background view with a tap recognizer that is hidden and shown when the drawer opens and closes
## Testing
1. Open and close the drawer on various screens by tapping outside the drawer
2. Verify that tapping controls/buttons does not trigger the action but instead closes the drawer
3. Verify once the drawer is closed the controls/buttons are clickable
4. Verify changing orientations doesn't change functionality 

---

Please Review: @Workiva/mobile  
