### PR TITLE
MOBILE-1790: Allow user to set transition duration.

### DIFF
--- a/Source/WCustomTransitions.swift
+++ b/Source/WCustomTransitions.swift
@@ -40,6 +40,7 @@ import UIKit
 
 public class SlideAnimationController: NSObject, UIViewControllerAnimatedTransitioning {
     public var presenting = true // Presenting or Dismissing (== push or pop)
+    public var transitionDuration = 1.0
 
     public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
         // If the reference to these views does not exist, we cannot animate a transition.
@@ -73,6 +74,6 @@ public class SlideAnimationController: NSObject, UIViewControllerAnimatedTransit
     }
 
     public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
-        return 1.0
+        return transitionDuration
     }
 }

--- a/Tests/WCustomTransitionsTests.swift
+++ b/Tests/WCustomTransitionsTests.swift
@@ -35,6 +35,8 @@ class WCustomTransitionsTests: QuickSpec {
 
                 subject.beginAppearanceTransition(true, animated: false)
                 subject.endAppearanceTransition()
+
+                animationController = SlideAnimationController()
             })
 
             afterEach({
@@ -43,15 +45,11 @@ class WCustomTransitionsTests: QuickSpec {
 
             describe("when app has been init") {
                 it("should init") {
-                    animationController = SlideAnimationController()
-
                     expect(animationController.presenting).to(beTruthy())
                     expect(animationController.transitionDuration(nil)) == 1.0
                 }
 
                 it("should perform animation without crash when presenting") {
-                    animationController = SlideAnimationController()
-
                     // All the views have to be set up in WCustomTransitioningContext in
                     // order to hit coverage requirement, this just verifies we do not crash.
                     let transitioningContext = WCustomTransitioningContext()
@@ -59,13 +57,20 @@ class WCustomTransitionsTests: QuickSpec {
                 }
 
                 it("should perform animation without crash when disappearing") {
-                    animationController = SlideAnimationController()
                     animationController.presenting = false
 
                     // All the views have to be set up in WCustomTransitioningContext in
                     // order to hit coverage requirement, this just verifies we do not crash.
                     let transitioningContext = WCustomTransitioningContext()
                     animationController.animateTransition(transitioningContext)
+                }
+
+                it("should allow transition duration to be set") {
+                    expect(animationController.transitionDuration(nil)) == 1.0
+
+                    animationController.transitionDuration = 0.8
+
+                    expect(animationController.transitionDuration(nil)) == 0.8
                 }
             }
         }


### PR DESCRIPTION
## Description

Consumer should be able to set transition duration of our push/pop animations.
## What Was Changed

Added said ability.
## Testing
- Verify unit tests pass.

---

Please Review: @Workiva/mobile  
