### PR TITLE
MOBILE-1832: Action Sheets not dismissing properly in all cases

### DIFF
--- a/Example/WMobileKitExample/ModalViewExamplesVC.swift
+++ b/Example/WMobileKitExample/ModalViewExamplesVC.swift
@@ -316,7 +316,7 @@ public class ModalViewExamplesVC: WSideMenuContentVC {
         }))
 
         actionSheetSort.hasCancel = false
-        actionSheetSort.dismissOnAction = true
+        actionSheetSort.dismissOnAction = false
         actionSheetSort.setSelectedAction(1)
         actionSheetSort.sheetSeparatorStyle = .All
         actionSheetSort.popoverPresentationController?.sourceView = sender

--- a/Source/WActionSheet.swift
+++ b/Source/WActionSheet.swift
@@ -525,14 +525,18 @@ public class WActionSheetVC<ActionDataType>: WBaseActionSheet<ActionDataType>, W
         if (indexPath.section == 0) {
             // perform handler
             if let action: WAction<ActionDataType> = actionForIndexPath(indexPath) {
-                if (!executeActionAfterDismissal) {
-                    action.handler?(action)
-                } else if (dismissOnAction) {
+                if (executeActionAfterDismissal) {
                     animateOut(0.1, completion: {
                         action.handler?(action)
                     })
+
+                    return
                 }
-            } else if (dismissOnAction) {
+
+                action.handler?(action)
+            }
+
+            if (dismissOnAction) {
                 animateOut(0.1)
             }
         }


### PR DESCRIPTION
## Description

Action sheets were not dismissing in all cases even when dismissOnAction flag was set to true.
## What Was Changed

Fixed action sheet dismissal logic.
## Testing
- Ensure unit tests still pass
- No unit tests added
- Ensure in the example app that the top 2 action sheet modals dismiss on action and the 3rd one (the sorting one) does not.

---

Please Review: @Workiva/mobile  
