### PR TITLE
MOBILE-1801: Add side padding to side buttons.

### DIFF
--- a/Source/WSideMenuVC.swift
+++ b/Source/WSideMenuVC.swift
@@ -268,6 +268,12 @@ public class WSideMenuVC: UIViewController {
 }
 
 public class WSideMenuContentVC: UIViewController, WSideMenuProtocol {
+    public var paddingBetweenBackAndMenuIcons: CGFloat = 20.0 {
+        didSet {
+            addWSideMenuButtons()
+        }
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -279,35 +285,37 @@ public class WSideMenuContentVC: UIViewController, WSideMenuProtocol {
         // Adds a button to open the side menu
         // If this VC is not the first rootVc for its nav controller, add a back button as well
         var sideMenuButtonItem: UIBarButtonItem = UIBarButtonItem()
-        
+
         if let sideMenuController = sideMenuController() {
             if let menuIcon = sideMenuController.options?.drawerIcon {
                 sideMenuButtonItem = UIBarButtonItem(image: menuIcon,
-                                                     style: .Plain,
-                                                     target: self,
-                                                     action: #selector(WSideMenuContentVC.toggleSideMenu))
+                    style: .Plain,
+                    target: self,
+                    action: #selector(WSideMenuContentVC.toggleSideMenu))
             } else {
                 sideMenuButtonItem = UIBarButtonItem(title: "Toggle",
-                                                     style: .Plain,
-                                                     target: self,
-                                                     action: #selector(WSideMenuContentVC.toggleSideMenu))
+                    style: .Plain,
+                    target: self,
+                    action: #selector(WSideMenuContentVC.toggleSideMenu))
             }
-            
+
             if (navigationController?.viewControllers.count > 1) {
                 var backMenuButtonItem = UIBarButtonItem()
-                
+
                 if let backIcon = sideMenuController.options?.backIcon {
                     backMenuButtonItem = UIBarButtonItem(image: backIcon,
-                                                         style: .Plain,
-                                                         target: self,
-                                                         action: #selector(WSideMenuContentVC.backButtonItemWasTapped(_:)))
+                        style: .Plain,
+                        target: self,
+                        action: #selector(WSideMenuContentVC.backButtonItemWasTapped(_:)))
                 } else {
                     backMenuButtonItem = UIBarButtonItem(title: "Back",
-                                                         style: .Plain,
-                                                         target: self,
-                                                         action: #selector(WSideMenuContentVC.backButtonItemWasTapped(_:)))
+                        style: .Plain,
+                        target: self,
+                        action: #selector(WSideMenuContentVC.backButtonItemWasTapped(_:)))
                 }
-                
+
+                sideMenuButtonItem.imageInsets = UIEdgeInsetsMake(0, -paddingBetweenBackAndMenuIcons, 0, paddingBetweenBackAndMenuIcons)
+
                 navigationItem.leftBarButtonItems = [backMenuButtonItem, sideMenuButtonItem]
             } else {
                 navigationItem.leftBarButtonItem = sideMenuButtonItem

--- a/Tests/WSideMenuVCTests.swift
+++ b/Tests/WSideMenuVCTests.swift
@@ -57,8 +57,6 @@ class WSideMenuVCSpec: QuickSpec {
                     let sideMenuVC = NSKeyedUnarchiver.unarchiveObjectWithFile(locToSave) as! WSideMenuVC
 
                     expect(sideMenuVC).toNot(equal(nil))
-
-                    // default settings from commonInit
                 }
 
                 it("should have the correct properties set") {
@@ -253,6 +251,22 @@ class WSideMenuVCSpec: QuickSpec {
                     expect(sideMenuContentVC.navigationItem.leftBarButtonItems?[1].title) == "Toggle"
                     expect(sideMenuContentVC.navigationItem.leftBarButtonItems?[1].style) == .Plain
                     expect(sideMenuContentVC.navigationItem.leftBarButtonItems?[1].action) == #selector(WSideMenuContentVC.toggleSideMenu)
+                    expect(sideMenuContentVC.navigationItem.leftBarButtonItems?[1].imageInsets) == UIEdgeInsetsMake(0, -20, 0, 20)
+                }
+
+                it("should have correct padding between menu and back icons") {
+                    let additionalController = UIViewController()
+                    mainNC.pushViewController(additionalController, animated: false)
+
+                    subject.options?.drawerIcon = nil
+                    subject.options?.backIcon = nil
+
+                    sideMenuContentVC.paddingBetweenBackAndMenuIcons = 10
+
+                    sideMenuContentVC.addWSideMenuButtons()
+
+                    expect(sideMenuContentVC.navigationItem.leftBarButtonItems?[1].title) == "Toggle"
+                    expect(sideMenuContentVC.navigationItem.leftBarButtonItems?[1].imageInsets) == UIEdgeInsetsMake(0, -10, 0, 10)
                 }
             }
         }


### PR DESCRIPTION
##### Non-breaking PR, this is able to be merged without its compliment ios ticket.

---
## Description

We wanted the padding between the hamburger icon and the back icon to be roughly half of what it was. 
## What Was Changed

Added an image padding (offset) to the menu icon _if_ there is a back button displayed. There will need to be a follow up ticket because this does not change the allocated frame of the image behind it, so the title can appear off centered with longer titles. I briefly looked at moving the title frame over the same distance as the padding but couldn't get a quick solution in. Spoke with Rich and he said it's not that concerning, but I explained we would want to get that done by release.
## Testing

Specific to get this PR merged:
- [ ] Unit tests pass.
- [ ] Changes look good. 

---

Please Review: @Workiva/mobile  
