### PR TITLE
MOBILE-1854: Adds check for multitasking mode

### DIFF
--- a/Source/WExtensions.swift
+++ b/Source/WExtensions.swift
@@ -54,12 +54,9 @@ public extension UILongPressGestureRecognizer {
     }
 }
 
-public extension UIApplication
-{
-    func isRunningInFullScreen() -> Bool
-    {
-        if let w = self.keyWindow
-        {
+public extension UIApplication {
+    func isRunningInFullScreen() -> Bool {
+        if let w = self.keyWindow {
             let maxScreenSize = max(UIScreen.mainScreen().bounds.size.width, UIScreen.mainScreen().bounds.size.height)
             let minScreenSize = min(UIScreen.mainScreen().bounds.size.width, UIScreen.mainScreen().bounds.size.height)
             let maxAppSize = max(w.bounds.size.width, w.bounds.size.height)


### PR DESCRIPTION
## Description

In order to have certain UI elements change depending on if the app is running in the iPad's multitasking mode, it is useful to have an extension allowing us to check at any time.

This is required for keypad changes in MOBILE-1854
## What Was Changed
- Adds a manual screen-size comparison check for whether we are in full screen or not (multitasking mode).
## Testing
- Make sure that UIApplication.sharedApplication().isRunningInFullScreen() returns the expected value when running the app. This can be done by throwing in a breakpoint and using the console.

---

Please Review: @Workiva/mobile  
