### PR TITLE
MOBILE-1950: Address retain cycles in v3

### DIFF
--- a/Source/WSideMenuVC.swift
+++ b/Source/WSideMenuVC.swift
@@ -48,7 +48,7 @@ enum WSideMenuState {
 
 public class WSideMenuVC: WSizeVC {
     // Setable properties
-    public var mainViewController: UIViewController?
+    weak public var mainViewController: UIViewController?
     public var leftSideMenuViewController: UIViewController?
     public var backgroundView: UIView!
     public var options: WSideMenuOptions?
@@ -264,6 +264,11 @@ public class WSideMenuVC: WSizeVC {
     @objc
     func backgroundWasTapped(sender: AnyObject) {
         closeSideMenu()
+    }
+    
+    deinit {
+        removeViewControllerFromContainer(mainViewController)
+        removeViewControllerFromContainer(leftSideMenuViewController)
     }
 }
 


### PR DESCRIPTION
## Description
- If you run the app using instruments you can see that our view controllers do a poor job of cleaning themselves up. Go through the app and remove any retain cycles that do not allow ARC to clean up our objects.
## What Was Changed
- Addressed retain cycles.
## Testing
1. Ensure unit tests pass.

---

Please Review: @Workiva/mobile  
