### PR TITLE
MOBILE-1957: Image in User Logo incorrectly sized

### DIFF
--- a/Source/WUserLogoView.swift
+++ b/Source/WUserLogoView.swift
@@ -122,6 +122,10 @@ public class WUserLogoView: UIView {
     }
 
     public func setupUI() {
+        if (CGRectEqualToRect(frame, CGRectZero)) {
+            return
+        }
+
         initialsLabel.snp_remakeConstraints { (make) in
             make.centerX.equalTo(self)
             make.centerY.equalTo(self)
@@ -235,7 +239,7 @@ public class WUserLogoView: UIView {
         dispatch_async(dispatch_get_global_queue(priority, 0)) {
             self.getDataFromUrl(url) { (data, response, error) in
                 self.imageData = data
-                
+
                 if (self.imageData == nil) {
                     // The image data failed to load,
                     // so clear the URL as well


### PR DESCRIPTION
## Description

When connecting to LinkedIn, the user logo images are not properly sized
## What Was Changed

Will not setup ui on user logo if the frame is CGRectZero
## Testing
- Ensure unit tests still pass
- Ensure user logo views with profile images look correct
- Test in Wdesk app by connecting to Linked In

---

Please Review: @Workiva/mobile  
