### PR TITLE
MOBILE-1995: Action Sheets have a retain cycle with their delegate

### DIFF
--- a/Example/WMobileKitExample/ModalViewExamplesVC.swift
+++ b/Example/WMobileKitExample/ModalViewExamplesVC.swift
@@ -208,31 +208,34 @@ public class ModalViewExamplesVC: WSideMenuContentVC {
         definesPresentationContext = true
 
         let actionSheet = WActionSheetVC<String>()
+        // Reference needs to be weak in the blocks to prevent retain cycles
+        weak var weakActionSheet = actionSheet
+
         actionSheet.titleString = "User Permissions"
 
         actionSheet.addAction(WAction(title: "Owner", subtitle: "Has full editing rights. May set other users' permissions.",
             handler: { action in
                 NSLog(action.title! + " was tapped")
-                actionSheet.deselectAction()
-                actionSheet.setSelectedAction(action)
+                weakActionSheet?.deselectAction()
+                weakActionSheet?.setSelectedAction(action)
         }))
         actionSheet.addAction(WAction(title: "Editor", subtitle: "May view and make changes to the document.",
             handler: { action in
                 NSLog(action.title! + " was tapped")
-                actionSheet.deselectAction()
-                actionSheet.setSelectedAction(action)
+                weakActionSheet?.deselectAction()
+                weakActionSheet?.setSelectedAction(action)
         }))
         actionSheet.addAction(WAction(title: "Viewer", subtitle: "May only view and comment on the document.",
             handler: { action in
                 NSLog(action.title! + " was tapped")
-                actionSheet.deselectAction()
-                actionSheet.setSelectedAction(action)
+                weakActionSheet?.deselectAction()
+                weakActionSheet?.setSelectedAction(action)
         }))
         actionSheet.addAction(WAction(title: "None (Remove Access)", subtitle: "Removes the collaborator's access to the document.", style: ActionStyle.Destructive,
             handler: { action in
                 NSLog(action.title! + " was tapped")
-                actionSheet.deselectAction()
-                actionSheet.setSelectedAction(action)
+                weakActionSheet?.deselectAction()
+                weakActionSheet?.setSelectedAction(action)
         }))
 
         actionSheet.setSelectedAction(1)
@@ -287,49 +290,51 @@ public class ModalViewExamplesVC: WSideMenuContentVC {
         definesPresentationContext = true
 
         let actionSheetSort = WActionSheetVC<String>()
+        // Reference needs to be weak in the blocks to prevent retain cycles
+        weak var weakActionSheet = actionSheetSort
 
         actionSheetSort.titleString = "Sort"
         actionSheetSort.addAction(WAction(title: "First Name",
             handler: { action in
                 NSLog(action.title! + " was tapped")
-                actionSheetSort.deselectAction()
-                actionSheetSort.setSelectedAction(action)
+                weakActionSheet?.deselectAction()
+                weakActionSheet?.setSelectedAction(action)
         }))
         actionSheetSort.addAction(WAction(title: "Last Name",
             handler: { action in
                 NSLog(action.title! + " was tapped")
-                actionSheetSort.deselectAction()
-                actionSheetSort.setSelectedAction(action)
+                weakActionSheet?.deselectAction()
+                weakActionSheet?.setSelectedAction(action)
         }))
         actionSheetSort.addAction(WAction(title: "Title",
             handler: { action in
                 NSLog(action.title! + " was tapped")
-                actionSheetSort.deselectAction()
-                actionSheetSort.setSelectedAction(action)
+                weakActionSheet?.deselectAction()
+                weakActionSheet?.setSelectedAction(action)
         }))
         actionSheetSort.addAction(WAction(title: "Subtitle",
             handler: { action in
                 NSLog(action.title! + " was tapped")
-                actionSheetSort.deselectAction()
-                actionSheetSort.setSelectedAction(action)
+                weakActionSheet?.deselectAction()
+                weakActionSheet?.setSelectedAction(action)
         }))
         actionSheetSort.addAction(WAction(title: "Section",
             handler: { action in
                 NSLog(action.title! + " was tapped")
-                actionSheetSort.deselectAction()
-                actionSheetSort.setSelectedAction(action)
+                weakActionSheet?.deselectAction()
+                weakActionSheet?.setSelectedAction(action)
         }))
         actionSheetSort.addAction(WAction(title: "Modified Date",
             handler: { action in
                 NSLog(action.title! + " was tapped")
-                actionSheetSort.deselectAction()
-                actionSheetSort.setSelectedAction(action)
+                weakActionSheet?.deselectAction()
+                weakActionSheet?.setSelectedAction(action)
         }))
         actionSheetSort.addAction(WAction(title: "Creation Date",
             handler: { action in
                 NSLog(action.title! + " was tapped")
-                actionSheetSort.deselectAction()
-                actionSheetSort.setSelectedAction(action)
+                weakActionSheet?.deselectAction()
+                weakActionSheet?.setSelectedAction(action)
         }))
 
         actionSheetSort.hasCancel = false
@@ -394,12 +399,12 @@ public class ModalViewExamplesVC: WSideMenuContentVC {
         topBanner?.hide()
 
         topBanner = WBannerView(rootView: view,
-                                 titleMessage: "Top Banner Title",
-                                 titleIcon: UIImage(named: "alert"),
-                                 bodyMessage: "This is the top tap to dismiss banner body. Banners can be dismissed by tapping them.",
-                                 rightIcon: UIImage(named: "close"),
-                                 bannerColor: UIColor(hex: 0x006400),
-                                 bannerAlpha: 0.8)
+            titleMessage: "Top Banner Title",
+            titleIcon: UIImage(named: "alert"),
+            bodyMessage: "This is the top tap to dismiss banner body. Banners can be dismissed by tapping them.",
+            rightIcon: UIImage(named: "close"),
+            bannerColor: UIColor(hex: 0x006400),
+            bannerAlpha: 0.8)
         topBanner!.delegate = self
         topBanner!.placement = .Top
         topBanner!.hideOptions = .DismissOnTap
@@ -410,10 +415,10 @@ public class ModalViewExamplesVC: WSideMenuContentVC {
         bottomBanner?.hide()
 
         bottomBanner = WBannerView(rootView: view,
-                                 titleMessage: "Bottom Banner Title",
-                                 titleIcon: UIImage(named: "alert"),
-                                 bodyMessage: "Body. Banners can be dismissed on a timer.",
-                                 bannerColor: UIColor(hex: 0x006400))
+            titleMessage: "Bottom Banner Title",
+            titleIcon: UIImage(named: "alert"),
+            bodyMessage: "Body. Banners can be dismissed on a timer.",
+            bannerColor: UIColor(hex: 0x006400))
         bottomBanner!.delegate = self
         bottomBanner!.show()
     }

--- a/Source/WTextField.swift
+++ b/Source/WTextField.swift
@@ -219,8 +219,6 @@ public class WTextField: UITextField {
                 rightView?.hidden = !(text == nil || text!.isEmpty)
             case .WhileEditing:
                 rightView?.hidden = (text == nil || text!.isEmpty)
-            default:
-                break
             }
         }
     }

--- a/Tests/WSideMenuVCTests.swift
+++ b/Tests/WSideMenuVCTests.swift
@@ -27,7 +27,6 @@ class WSideMenuVCSpec: QuickSpec {
             var window: UIWindow!
             var mainNC: UINavigationController!
             var mainVC: UIViewController!
-            var subNC: UINavigationController!
             var leftSideMenuVC: UIViewController!
 
             beforeEach({


### PR DESCRIPTION
## Description

The delegates on all action sheets are not set to weak and thus seem to be causing retain cycles.
## What Was Changed
- Added weak to delegates in the action sheet.
- Changed WBaseActionSheetDelegate to a class. 
## Testing
1. Test app using instruments and make sure actionSheets are not retained

---

Please Review: @Workiva/mobile  
