### PR TITLE
MOBILE-1972: Submit text button in auto complete should be bigger

### DIFF
--- a/Source/WAutoCompleteTextView.swift
+++ b/Source/WAutoCompleteTextView.swift
@@ -141,7 +141,6 @@ public class WAutoCompleteTextView: UIView {
         submitButton.setTitle("Submit", forState: .Normal)
         submitButton.setTitleColor(.darkGrayColor(), forState: .Normal)
         submitButton.titleLabel?.numberOfLines = 1
-        submitButton.titleLabel?.font = UIFont.systemFontOfSize(12)
         submitButton.titleLabel?.adjustsFontSizeToFitWidth = true
         submitButton.backgroundColor = .clearColor()
         submitButton.hidden = true


### PR DESCRIPTION
## Description

After the user types his/her reply, the "reply" button text is too small. Button text should be disabled until user enters >0 characters.
## What Was Changed
- Removed hardcoded font size so that submit button label adjusts to button size
## Testing
- Ensure unit tests pass
- Verify in Wdesk app that the "Reply" button has an acceptable font size

---

Please Review: @Workiva/mobile  
- Verbal UX +1 received by @richuhl-wf 
