### PR TITLE
MOBILE-1977: RELEASE w-mobile-kit 0.0.2

### DIFF
--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
+	<string>0.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
+	<string>0.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'UI kit for common Swift components.'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.homepage         = 'https:app.wdesk.com'


### PR DESCRIPTION
Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w-mobile-kit 0.0.2 items =======

 MOBILE-1995  - Action Sheets have a retain cycle with their delegate  - https://github.com/Workiva/w-mobile-kit/pull/68

 MOBILE-2008  - Update w-mobile-kit README for open source release  - https://github.com/Workiva/w-mobile-kit/pull/70

 MOBILE-1972  - "Reply" text button in Discussions should be bigger  - https://github.com/Workiva/w-mobile-kit/pull/69

 MOBILE-1989  - Change LinkedIn user icon outline color on drawer.  - https://github.com/Workiva/w-mobile-kit/pull/67

======= end =======

---

Please Review: @Workiva/mobile  
