### PR TITLE
MOBILE-2071: Crash when selecting action sheet item then dismissing action sheet

### DIFF
--- a/Source/WActionSheet.swift
+++ b/Source/WActionSheet.swift
@@ -128,9 +128,9 @@ public class WBaseActionSheet<ActionDataType>: UIViewController {
 
     // In case an action is tapped during dismissal, still call its completion handler
     public override func dismissViewControllerAnimated(flag: Bool, completion: (() -> Void)?) {
-        let newCompletion: (() -> Void) = { Void in
+        let newCompletion: (() -> Void) = { [weak self] Void in
             completion?()
-            self.completionToHandle?()
+            self?.completionToHandle?()
         }
 
         super.dismissViewControllerAnimated(flag, completion: newCompletion)


### PR DESCRIPTION
## Description

In cases where an action sheet gets dismissed twice (selecting an action item + tapping cancel/outside the sheet), a crash occurs due to the completion handlers expecting self to not be nil
## What Was Changed
- Switched animate out handlers to weak self because it isn't guaranteed to exist
- Also added isDismissing flag to prevent weird animation jump if user dismisses action sheet twice
## Testing
- Ensure all unit tests pass
- Verify in Wdesk app (check out this branch in the submodule)
  - Open the appspot selection action sheet
    - Tap a different appspot and outside of the action sheet to dismiss immediately after
  - Open the action sheet for entities in all files/recents
    - Tap "Permissions" and outside of the action sheet immediately after
  - Verify these scenarios (and any others I missed) do not crash the app

---

Please Review: @Workiva/mobile  
