### PR TITLE
MOBILE-2017: RELEASE w-mobile-kit 0.0.3

### DIFF
--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.2</string>
+	<string>0.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.2</string>
+	<string>0.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '0.0.2'
+  s.version          = '0.0.3'
   s.summary          = 'UI kit for common Swift components.'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.homepage         = 'https:app.wdesk.com'


### PR DESCRIPTION
Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w-mobile-kit 0.0.3 items =======

 MOBILE-2022  - On desktop users are not able to send Task reminders to themselves.  - https://github.com/Workiva/w-mobile-kit/pull/73

 MOBILE-2071  - Crash when selecting action sheet item "Permissions" then dismissing action sheet  - https://github.com/Workiva/w-mobile-kit/pull/72

======= end =======

---

Please Review: @Workiva/mobile  
