### PR TITLE
MOBILE-2090: Update w-mobile-kit podspec to Workiva specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ WMobileKit is a Swift library containing various custom UI components to provide
 
 ## Usage
 
-To run the example project, clone the repo, and run `pod install` from the Example directory first.
+To use the library in your app, add the following import to your file:
+```swift
+import WMobileKit
+```
+
+To run the example project, run `./setup.sh` in the root directory.
+Alternatively, you can run `pod install` from the Example directory.
 
 ## Requirements
 
@@ -41,6 +47,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ## Installation
 
+Add the following to your Podfile:
 ```ruby
 pod "WMobileKit"
 ```
@@ -61,3 +68,11 @@ Solution:
 ## License
 
 WMobileKit is available under the Apache license. See the LICENSE file for more info.
+
+## Authors
+- James Romo
+- Jordan Ross
+- Jeff Scaturro
+- Todd Tarbox
+- Brian Blanchard
+- Bryan Rezende

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -6,11 +6,15 @@
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
   s.version          = '0.0.3'
-  s.summary          = 'UI kit for common Swift components.'
-  s.license          = { :type => 'MIT', :file => 'LICENSE' }
-  s.homepage         = 'https:app.wdesk.com'
-#  s.homepage         = 'https://github.com/Workiva/w-mobile-kit'
-  s.author           = { 'Workiva' => 'https://github.com/Workiva' }
+  s.summary          = 'Swift library containing various custom UI components to provide functionality outside of the default libraries.'
+  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.homepage         = 'https://github.com/Workiva/w-mobile-kit'
+  s.authors          = { 'James Romo' => 'james.romo@workiva.com',
+                         'Jordan Ross' => 'jordan.ross@workiva.com',
+                         'Jeff Scaturro' => 'jeff.scaturro@workiva.com',
+                         'Todd Tarbox' => 'todd.tarbox@workiva.com',
+                         'Brian Blanchard' => 'brian.blanchard@workiva.com',
+                         'Bryan Rezende' => 'bryan.rezende@workiva.com' }
   s.source           = { :git => 'https://github.com/Workiva/w-mobile-kit.git', :tag => s.version.to_s }
   s.platform         = :ios, '8.0'
   s.requires_arc     = true


### PR DESCRIPTION
Description
---
Update the podspec in mobile kit to match the pubspec (as close as possible) specified here: https://wiki.atl.workiva.net/display/DEV/Open+Source+Software+-+OSS+-+External+Publishing+Process

What Was Changed
---
- Updated podspec to workiva specifications
    - Author name order is based on current contributions

Testing
---
1. Run ```pod lib lint --allow-warnings``` in the root and verify it passes
2. Verify everything was spelled correctly and looks professional/correct in ```WMobileKit.podspec```

---

Please Review: @Workiva/mobile  

