### PR TITLE
MOBILE-2030: Adding check to prevent crash

### DIFF
--- a/Source/WSizeVC.swift
+++ b/Source/WSizeVC.swift
@@ -85,11 +85,13 @@ public class WSizeVC: UIViewController {
     public func verticalSizeClassChanged(verticalSizeClass: UIUserInterfaceSizeClass) {}
 
     public func updateContentContainerPadding() {
-        sizeContentContainer().snp_updateConstraints(closure: { (make) in
-            make.left.equalTo(view).offset(contentContainerSidePadding)
-            make.right.equalTo(view).offset(-contentContainerSidePadding)
-            make.top.equalTo(view).offset(contentContainerTopPadding)
-            make.bottom.equalTo(view).offset(-contentContainerBottomPadding)
-        })
+        if (view.subviews.contains(sizeContentContainer())) {
+            sizeContentContainer().snp_updateConstraints(closure: { (make) in
+                make.left.equalTo(view).offset(contentContainerSidePadding)
+                make.right.equalTo(view).offset(-contentContainerSidePadding)
+                make.top.equalTo(view).offset(contentContainerTopPadding)
+                make.bottom.equalTo(view).offset(-contentContainerBottomPadding)
+            })
+        }
     }
 }


### PR DESCRIPTION
Description
---
- Fixing crash in the `WSizeVC`.

What Was Changed
---
- Added a check to ensure constraints are only added when the view as been added

Testing
---
- Follow testing instruction in `wdesk-ios` repo.

---

Please Review: @Workiva/mobile  

