### PR TITLE
MOBILE-2091: RELEASE w-mobile-kit 0.0.5

### DIFF
--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.4</string>
+	<string>0.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.4</string>
+	<string>0.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '0.0.4'
+  s.version          = '0.0.5'
   s.summary          = 'Swift library containing various custom UI components to provide functionality outside of the default libraries.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/Workiva/w-mobile-kit'


### PR DESCRIPTION
Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w-mobile-kit 0.0.5 items =======

 MOBILE-2025  - Show LinkedIn profile picture in place of ALL user logos for the current user  - https://github.com/Workiva/w-mobile-kit/pull/76
 MOBILE-2026  - Show LinkedIn profile picture for all users who have connected  - https://github.com/Workiva/w-mobile-kit/pull/76

 MOBILE-2030  - UX improvements for unbound Tasks (not connected to a document)  - https://github.com/Workiva/w-mobile-kit/pull/78

======= end =======


---

Please Review: @Workiva/mobile  

