### PR TITLE
swipe-to-open: Adding swipe to open drawer with custom options

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - SDWebImage/Core (= 3.8.0)
   - SDWebImage/Core (3.8.0)
   - SnapKit (0.20.0)
-  - WMobileKit (0.0.4):
+  - WMobileKit (0.0.5):
     - CryptoSwift (~> 0.4)
     - SDWebImage (= 3.8)
     - SnapKit (~> 0.20.0)
@@ -20,7 +20,7 @@ SPEC CHECKSUMS:
   CryptoSwift: 25b5aff3f260967391f8fff2e9abe4254d2c6fd5
   SDWebImage: 7d9fe229266696de91eadf840c77ca15efd4bbd2
   SnapKit: 5fce3c1bbbf1fbd31de9aa92f33eb9fa03f15650
-  WMobileKit: 79d3566588fa0443ef1cd4f3c5f0eef0a29a8592
+  WMobileKit: 142abe4893a08a2085251197783b69dd81037215
 
 PODFILE CHECKSUM: fb0ddbcd40ed7b9c9487bbb0e366869765e5df23
 

--- a/Example/WMobileKitExample/SideMenuVCExample.swift
+++ b/Example/WMobileKitExample/SideMenuVCExample.swift
@@ -26,6 +26,7 @@ class SideMenuVCExample: WSideMenuVC {
         var menuOptions = WSideMenuOptions()
         menuOptions.menuWidth = (UIDevice.currentDevice().userInterfaceIdiom == .Pad) ? 320 : 300
         menuOptions.drawerIcon = UIImage(named: "drawer")
+        menuOptions.swipeToOpen = true
         options = menuOptions
 
         let leftMenu = mainStoryboard.instantiateViewControllerWithIdentifier("LeftMenu") as! LeftMenuTVCExample

--- a/Source/WSideMenuVC.swift
+++ b/Source/WSideMenuVC.swift
@@ -257,9 +257,11 @@ public class WSideMenuVC: WSizeVC {
     }
     
     public func hideStatusBar(hide: Bool) {
+        statusBarHidden = hide
+        
         if let window = UIApplication.sharedApplication().delegate?.window {
-            window?.windowLevel = hide ? UIWindowLevelStatusBar : UIWindowLevelNormal
-        }                
+            window?.windowLevel = hide ? UIWindowLevelStatusBar : UIWindowLevelNormal            
+        }
     }
     
     public func percentageMoved() -> CGFloat {

--- a/Source/WSideMenuVC.swift
+++ b/Source/WSideMenuVC.swift
@@ -213,9 +213,9 @@ public class WSideMenuVC: WSizeVC {
                 leftSideMenuContainerView.center.x = newCenter
                 recognizer.setTranslation(CGPointZero, inView: view)
             case .Ended:
-                // If the drawer has animated more than half way, open it
-                let x = abs(leftSideMenuContainerView.frame.origin.x)                
+                let x = abs(leftSideMenuContainerView.frame.origin.x)
                 
+                // If the drawer has animated out past the threshold, open it
                 if (x < width * options!.autoOpenThreshold) {
                     openSideMenu()
                 } else {

--- a/Source/WSideMenuVC.swift
+++ b/Source/WSideMenuVC.swift
@@ -257,13 +257,9 @@ public class WSideMenuVC: WSizeVC {
     }
     
     public func hideStatusBar(hide: Bool) {
-        statusBarHidden = hide
-        
-        if (hide) {
-            UIApplication.sharedApplication().delegate?.window!!.windowLevel = UIWindowLevelStatusBar
-        } else {
-            UIApplication.sharedApplication().delegate?.window!!.windowLevel = UIWindowLevelNormal
-        }
+        if let window = UIApplication.sharedApplication().delegate?.window {
+            window?.windowLevel = hide ? UIWindowLevelStatusBar : UIWindowLevelNormal
+        }                
     }
     
     public func percentageMoved() -> CGFloat {

--- a/Source/WSideMenuVC.swift
+++ b/Source/WSideMenuVC.swift
@@ -36,6 +36,7 @@ public struct WSideMenuOptions {
     public var swipeToOpenThreshold: CGFloat = 0.33
     public var autoOpenThreshold: CGFloat = 0.5
     public var useBlur = true
+    public var shadowOpacity: Float = 0.3
     public var showAboveStatusBar = true
     public var menuAnimationDuration = 0.3
     public var gesturesOpenSideMenu = true
@@ -212,6 +213,10 @@ public class WSideMenuVC: WSizeVC {
                 
                 leftSideMenuContainerView.center.x = newCenter
                 recognizer.setTranslation(CGPointZero, inView: view)
+                
+                // animate the shadow based on the percentage the drawer has animated in
+                let percentageMoved = 1 - (abs(leftSideMenuContainerView.frame.origin.x) / width)
+                leftSideMenuContainerView.layer.shadowOpacity = Float(percentageMoved) * options!.shadowOpacity            
             case .Ended:
                 let x = abs(leftSideMenuContainerView.frame.origin.x)
                 
@@ -286,7 +291,7 @@ public class WSideMenuVC: WSizeVC {
         UIView.animateWithDuration(options!.menuAnimationDuration,
             animations: {
                 self.view.layoutIfNeeded()
-                self.leftSideMenuContainerView.layer.shadowOpacity = 0.3
+                self.leftSideMenuContainerView.layer.shadowOpacity = self.options!.shadowOpacity
             },
             completion: { finished in
                 self.menuState = .Open


### PR DESCRIPTION
Description
---
- Added swipe to open drawer with custom options.

What Was Changed
---
- Added pan gesture with logic to handle the swipe to open and close the drawer.
- Added new options for the `WSideMenuVC`:
    - `swipeToOpen`: The one flag that needs to be enabled to allow the user to swipe to open the drawer
    - `swipeToOpenThreshold`: The percentage of the left side of the view used that can be swiped on and the drawer will open. Defaults to the left third.
    - `autoOpenThreshold`: The percentage the drawer has to be swiped before it will automatically open. Defaults to halfway open.

Testing
---
1. Run the sample app and swiping to open the drawer from anywhere should work.
* Swiping right on the left third of the main view will start to open the drawer.
* Releasing before the drawer reaches half way should close the drawer.
* Releasing after the drawer reaches half way should open the drawer.
* Swiping the left when the drawer is closed should do nothing.
* Swiping anywhere outside the drawer when it is open should start to close it.

---

Please Review: @Workiva/mobile  

