### PR TITLE
MOBILE-2151: [iOS 10] Status bar changes color when action sheet is displayed

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - SDWebImage/Core (= 3.8.0)
   - SDWebImage/Core (3.8.0)
   - SnapKit (0.20.0)
-  - WMobileKit (0.0.4):
+  - WMobileKit (0.0.5):
     - CryptoSwift (~> 0.4)
     - SDWebImage (= 3.8)
     - SnapKit (~> 0.20.0)
@@ -14,13 +14,13 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   WMobileKit:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   CryptoSwift: 25b5aff3f260967391f8fff2e9abe4254d2c6fd5
   SDWebImage: 7d9fe229266696de91eadf840c77ca15efd4bbd2
   SnapKit: 5fce3c1bbbf1fbd31de9aa92f33eb9fa03f15650
-  WMobileKit: 79d3566588fa0443ef1cd4f3c5f0eef0a29a8592
+  WMobileKit: 142abe4893a08a2085251197783b69dd81037215
 
 PODFILE CHECKSUM: fb0ddbcd40ed7b9c9487bbb0e366869765e5df23
 

--- a/Source/WActionSheet.swift
+++ b/Source/WActionSheet.swift
@@ -44,6 +44,9 @@ internal protocol WBaseActionSheetDelegate: class {
     func setSelectedAction(index: Int)
 }
 
+// This view controller manages the status bar for the UIWindow that is created by
+//   the properties of the status bar from the view controller presenting it
+//   as it is the root view controller of the window
 class WActionSheetStatusBarController: UIViewController {
     var previousStatusBarStyle: UIStatusBarStyle?
     var previousStatusBarHidden: Bool?

--- a/Source/WActionSheet.swift
+++ b/Source/WActionSheet.swift
@@ -44,6 +44,19 @@ internal protocol WBaseActionSheetDelegate: class {
     func setSelectedAction(index: Int)
 }
 
+class WActionSheetStatusBarController: UIViewController {
+    var previousStatusBarStyle: UIStatusBarStyle?
+    var previousStatusBarHidden: Bool?
+
+    override func prefersStatusBarHidden() -> Bool {
+        return previousStatusBarHidden == nil ? false : previousStatusBarHidden!
+    }
+
+    override func preferredStatusBarStyle() -> UIStatusBarStyle {
+        return previousStatusBarStyle == nil ? .Default : previousStatusBarStyle!
+    }
+}
+
 public class WBaseActionSheet<ActionDataType>: UIViewController {
     public var presentingWindow: UIWindow? = UIWindow(frame: UIScreen.mainScreen().bounds)
 
@@ -54,8 +67,17 @@ public class WBaseActionSheet<ActionDataType>: UIViewController {
 
     internal weak var delegate: WBaseActionSheetDelegate!
 
-    var previousStatusBarStyle: UIStatusBarStyle?
-    var previousStatusBarHidden: Bool?
+    var statusBarStyleController = WActionSheetStatusBarController()
+    var previousStatusBarStyle: UIStatusBarStyle? {
+        didSet {
+            statusBarStyleController.previousStatusBarStyle = previousStatusBarStyle
+        }
+    }
+    var previousStatusBarHidden: Bool? {
+        didSet {
+            statusBarStyleController.previousStatusBarHidden = previousStatusBarHidden
+        }
+    }
 
     // An optional completion handler to store in case an action is tapped while the action sheet is already dismissing
     var completionToHandle: (() -> Void)?
@@ -73,14 +95,6 @@ public class WBaseActionSheet<ActionDataType>: UIViewController {
 
     public convenience init() {
         self.init(nibName: nil, bundle: nil)
-    }
-
-    public override func prefersStatusBarHidden() -> Bool {
-        return previousStatusBarHidden == nil ? false : previousStatusBarHidden!
-    }
-
-    public override func preferredStatusBarStyle() -> UIStatusBarStyle {
-        return previousStatusBarStyle == nil ? .Default : previousStatusBarStyle!
     }
 
     public override func viewWillAppear(animated: Bool) {
@@ -137,11 +151,13 @@ public class WBaseActionSheet<ActionDataType>: UIViewController {
     }
 
     public func commonInit() {
+        statusBarStyleController.view.userInteractionEnabled = false
+
         view.backgroundColor = UIColor.whiteColor().colorWithAlphaComponent(0.0)
 
         presentingWindow?.windowLevel = UIWindowLevelStatusBar + 1
         presentingWindow?.backgroundColor = UIColor.whiteColor().colorWithAlphaComponent(0.0)
-        presentingWindow?.rootViewController = self
+        presentingWindow?.rootViewController = statusBarStyleController
         presentingWindow?.hidden = true
 
         presentingWindow?.addSubview(tapRecognizerView)

--- a/Tests/WActionSheetTests.swift
+++ b/Tests/WActionSheetTests.swift
@@ -129,15 +129,15 @@ class WActionSheetSpec: QuickSpec {
                     subject.previousStatusBarStyle = .LightContent
                     subject.previousStatusBarHidden = true
                     
-                    expect(subject.prefersStatusBarHidden()) == true
-                    expect(subject.preferredStatusBarStyle()) == UIStatusBarStyle.LightContent
+                    expect(subject.statusBarStyleController.prefersStatusBarHidden()) == true
+                    expect(subject.statusBarStyleController.preferredStatusBarStyle()) == UIStatusBarStyle.LightContent
                 }
                 
                 it("should set window and subview properties correctly") {
                     expect(subject.presentingWindow).toNot(beNil())
                     expect(subject.presentingWindow!.hidden) == false
                     expect(subject.presentingWindow!.windowLevel) == UIWindowLevelStatusBar + 1
-                    expect(subject.presentingWindow!.rootViewController) == subject
+                    expect(subject.presentingWindow!.rootViewController) == subject.statusBarStyleController
                     
                     expect(subject.tapRecognizerView.backgroundColor) == UIColor.blackColor().colorWithAlphaComponent(0.4)
                     expect(subject.tapRecognizerView.gestureRecognizers?.count) == 1


### PR DESCRIPTION
Description
---
Status bar changes color when action sheet is displayed (i.e. goes back to a grey status bar instead of white).

What Was Changed
---
The UIWindow that gets created when an action sheet is shown now has a new rootViewController that solely manages the status bar style/hidden preference from the presenting view controller.

Testing
---
* Ensure unit tests pass
* Ensure on iOS 9 and iOS 10 that presenting an action sheet keeps the style of the status bar
 * Can witness this in the Mobile Kit example app on iOS 10
 * Can also copy the WActionSheet.swift file manually into the Wdesk app and verify it works as well on iOS 10 devices

---

Please Review: @Workiva/mobile  
