### PR TITLE
MOBILE-2155: Action Sheet Status Bar Grabbing Incorrect Style

### DIFF
--- a/Source/WActionSheet.swift
+++ b/Source/WActionSheet.swift
@@ -106,13 +106,8 @@ public class WBaseActionSheet<ActionDataType>: UIViewController {
         checkForPresentingWindow()
 
         if let presentingVC = presentationController?.presentingViewController {
-            if let navVC = presentingVC.navigationController {
-                previousStatusBarHidden = navVC.prefersStatusBarHidden()
-                previousStatusBarStyle = navVC.preferredStatusBarStyle()
-            } else {
-                previousStatusBarHidden = presentingVC.prefersStatusBarHidden()
-                previousStatusBarStyle = presentingVC.preferredStatusBarStyle()
-            }
+            previousStatusBarHidden = UIApplication.sharedApplication().statusBarHidden
+            previousStatusBarStyle = UIApplication.sharedApplication().statusBarStyle
 
             setNeedsStatusBarAppearanceUpdate()
         }


### PR DESCRIPTION
Description
---
The action sheet currently shows the status bar according to the navigation controller or the presenting controller, but those aren't always in control of the status bar.

What Was Changed
---
Status bar style for action sheets is now dictated by whatever the current style is no matter what view controller is controlling it

Testing
---
* Ensure when action sheets are presented in Mobile Kit, the status bar maintains its style
* Make the same diff manually in Wdesk and ensure the status bars maintain their style

---

Please Review: @Workiva/mobile  