### PR TITLE
MOBILE-2103: Version bump to 0.0.6

### DIFF
--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.5</string>
+	<string>0.0.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.5</string>
+	<string>0.0.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '0.0.5'
+  s.version          = '0.0.6'
   s.summary          = 'Swift library containing various custom UI components to provide functionality outside of the default libraries.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/Workiva/w-mobile-kit'


### PR DESCRIPTION
Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w-mobile-kit 0.0.6 items =======

 MOBILE-2155  - Action Sheet Status Bar Grabbing Incorrect Style  - https://github.com/Workiva/w-mobile-kit/pull/83

 MOBILE-2155  - Action Sheet Status Bar Grabbing Incorrect Style  - https://github.com/Workiva/w-mobile-kit/pull/82
swipe-to-open: Adding swipe to open drawer with custom options  - https://github.com/Workiva/w-mobile-kit/pull/80

 MOBILE-2151  - [iOS 10] Status bar changes color when action sheet is displayed.  - https://github.com/Workiva/w-mobile-kit/pull/81

======= end =======

---

Please Review: @Workiva/mobile  

