### PR TITLE
MOBILE-2160: Pin down mobile-kit dependencies in WMobileKit.podspec

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
-  - CryptoSwift (0.4.1)
+  - CryptoSwift (0.5.2)
   - SDWebImage (3.8.0):
     - SDWebImage/Core (= 3.8.0)
   - SDWebImage/Core (3.8.0)
   - SnapKit (0.20.0)
-  - WMobileKit (0.0.5):
-    - CryptoSwift (~> 0.4)
+  - WMobileKit (0.0.6):
+    - CryptoSwift (= 0.5.2)
     - SDWebImage (= 3.8)
-    - SnapKit (~> 0.20.0)
+    - SnapKit (= 0.20.0)
 
 DEPENDENCIES:
   - WMobileKit (from `../`)
 
 EXTERNAL SOURCES:
   WMobileKit:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  CryptoSwift: 25b5aff3f260967391f8fff2e9abe4254d2c6fd5
+  CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
   SDWebImage: 7d9fe229266696de91eadf840c77ca15efd4bbd2
   SnapKit: 5fce3c1bbbf1fbd31de9aa92f33eb9fa03f15650
-  WMobileKit: 142abe4893a08a2085251197783b69dd81037215
+  WMobileKit: 66ddea5172f560a9b5b74eab2e1061c6450021ae
 
 PODFILE CHECKSUM: fb0ddbcd40ed7b9c9487bbb0e366869765e5df23
 

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 def common_pods
   pod 'SnapKit', '0.20.0'
-  pod 'CryptoSwift', '0.4'
+  pod 'CryptoSwift', '0.5.2'
   pod 'SDWebImage', '3.8'
 end
 
@@ -13,6 +13,6 @@ end
 
 target 'WMobileKitTests' do
   common_pods
-  pod 'Quick', '~> 0.9.1'
-  pod 'Nimble', '~> 4.0.0'
+  pod 'Quick', '0.9.3'
+  pod 'Nimble', '4.1.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
-  - CryptoSwift (0.4)
-  - Nimble (4.0.0)
-  - Quick (0.9.1)
+  - CryptoSwift (0.5.2)
+  - Nimble (4.1.0)
+  - Quick (0.9.3)
   - SDWebImage (3.8.0):
     - SDWebImage/Core (= 3.8.0)
   - SDWebImage/Core (3.8.0)
   - SnapKit (0.20.0)
 
 DEPENDENCIES:
-  - CryptoSwift (= 0.4)
-  - Nimble (~> 4.0.0)
-  - Quick (~> 0.9.1)
+  - CryptoSwift (= 0.5.2)
+  - Nimble (= 4.1.0)
+  - Quick (= 0.9.3)
   - SDWebImage (= 3.8)
   - SnapKit (= 0.20.0)
 
 SPEC CHECKSUMS:
-  CryptoSwift: 584eac7d00b2f497fe7b20de271b8c0c52fff844
-  Nimble: 72bcc3e2f02242e6bfaaf8d9412ca7bfe3d8b417
-  Quick: a5221fc21788b6aeda934805e68b061839bc3165
+  CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
+  Nimble: 97a0a4cae5124c117115634b2d055d8c97d0af19
+  Quick: 13a2a2b19a5d8e3ed4fd0c36ee46597fd77ebf71
   SDWebImage: 7d9fe229266696de91eadf840c77ca15efd4bbd2
   SnapKit: 5fce3c1bbbf1fbd31de9aa92f33eb9fa03f15650
 
-PODFILE CHECKSUM: 2a89d241fca45f00cd684abfe2f5cfd3c09e5c08
+PODFILE CHECKSUM: 5a0e08d24916cea2d19b4add532ea7c801c61fb5
 
 COCOAPODS: 1.0.0

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '8.0'
   s.requires_arc     = true
   s.source_files     = 'Source/*{h,m,swift}'
-  s.dependency 'SnapKit', '~> 0.20.0'
-  s.dependency 'CryptoSwift', '~> 0.4'
+  s.dependency 'SnapKit', '0.20.0'
+  s.dependency 'CryptoSwift', '0.5.2'
   s.dependency 'SDWebImage', '3.8'
 end

--- a/smithy.sh
+++ b/smithy.sh
@@ -44,6 +44,12 @@ function archive_code_coverage {
     zip -r -X code_coverage/coverage.zip xcov
 }
 
+# Verify library status
+pod lib lint WMobileKit.podspec --allow-warnings
+if [ $? -ne 0 ]; then
+  print_error "ERROR: Library check failed. Verify WMobileKit.podspec."
+fi
+
 ./build.sh
 
 # Running unit tests, we need to open the simulator to make sure xcodebuild knows that it is open.

--- a/smithy.sh
+++ b/smithy.sh
@@ -8,8 +8,7 @@ code_coverage_threshold=90
 PATH="$(cd ~/; pwd)/.rbenv/shims:$(cd ~/; pwd)/.rbenv/bin:$PATH"
 
 function run_unit_tests() {
-    echo
-    echo "Starting $1 unit tests."
+    print_heading "Starting $1 unit tests."
 
     xcodebuild clean test -workspace WMobileKit.xcworkspace -scheme WMobileKit -configuration Debug -destination \
     "platform=iOS Simulator,name=$1,OS=8.4" -enableCodeCoverage YES | ocunit2junit
@@ -38,37 +37,34 @@ function clean_previous_build {
 }
 
 function archive_code_coverage {
-    echo
-    echo "Archiving code coverage reports."
+    print_heading "Archiving code coverage reports."
     mkdir code_coverage
     zip -r -X code_coverage/coverage.zip xcov
 }
 
-# Verify library status
+# Validate library status
+print_heading "Validating WMobileKit.podspec"
 pod lib lint WMobileKit.podspec --allow-warnings
 if [ $? -ne 0 ]; then
-  print_error "ERROR: Library check failed. Verify WMobileKit.podspec."
+  print_error "ERROR: Library validation failed. Verify WMobileKit.podspec."
 fi
 
 ./build.sh
 
 # Running unit tests, we need to open the simulator to make sure xcodebuild knows that it is open.
 clean_previous_build
-echo
-echo "Starting iPad Retina Simulator."
+print_heading "Starting iPad Retina Simulator."
 run_unit_tests "iPad Retina"
 
 # Running unit tests, we need to open the simulator to make sure xcodebuild knows that it is open.
 clean_previous_build
-echo
-echo "Starting iPhone 5 Simulator."
+print_heading "Starting iPhone 5 Simulator."
 run_unit_tests "iPhone 5"
 
 # Clean up and ensure the sim is killed
 clean_previous_build
 
-echo
-echo "Generating code coverage report"
+print_heading "Generating code coverage report"
 xcov -m $code_coverage_threshold -w WMobileKit.xcworkspace -s WMobileKit -o xcov
 
 # If code coverage is not at least the minimum, stop here.

--- a/version_bump.sh
+++ b/version_bump.sh
@@ -8,13 +8,29 @@ function usage {
     echo "    ./version_bump.sh 2.6.0 2.6.1"
 }
 
-if [[ "$#" -lt 1 ]] ; then
-    usage
-else
+# Usage: updateVersion $arg1 $arg2
+function updateVersion {
+    echo
+    echo "Updating version from $1 to $2"
+    echo
     # Spaces are necessary
     sed -i "" -E "s/s.version          = '$1'/s.version          = '$2'/g" WMobileKit.podspec
 
     sed -i "" -E "s/<string>$1<\/string>/<string>$2<\/string>/g" Source/Info.plist
 
     sed -i "" -E "s/<string>$1<\/string>/<string>$2<\/string>/g" Example/WMobileKitExample/Info.plist
+}
+
+function updatePods {
+    echo
+    echo "Updating Pods for new version"
+    echo
+    ./setup.sh
+}
+
+if [[ "$#" -lt 1 ]] ; then
+    usage
+else
+    updateVersion $1 $2
+    updatePods
 fi

--- a/version_bump.sh
+++ b/version_bump.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source core.sh
 
 function usage {
     echo "${underline}${bold}Usage${normal}"
@@ -10,9 +11,7 @@ function usage {
 
 # Usage: updateVersion $arg1 $arg2
 function updateVersion {
-    echo
-    echo "Updating version from $1 to $2"
-    echo
+    print_heading "Updating version from $1 to $2"
     # Spaces are necessary
     sed -i "" -E "s/s.version          = '$1'/s.version          = '$2'/g" WMobileKit.podspec
 
@@ -22,9 +21,7 @@ function updateVersion {
 }
 
 function updatePods {
-    echo
-    echo "Updating Pods for new version"
-    echo
+    print_heading "Updating Pods for new version"
     ./setup.sh
 }
 


### PR DESCRIPTION
Description
---
The versions of the decencies in mobile-kit are not currently pinned down and causing issues since they are updating to newer versions of swift than we are currently compatible with. These should be pinned down in both the podfiles and the podspec. 

What Was Changed
---
- Pinned down podspec libraries. 
- Bumped and pinned down testing libraries.
- Updated version bump script to update pods so both the library and example app pod files are kept up to date with each release.
- Added library validation to smithy.

Testing
---
1. Run ```./version_bump.sh 0.0.6 0.0.7```
2. Verify the version bump occurs on the correct files and both the main library and example app reflect the new changes to use 0.0.7 and any other pod updates.
3. Verify both pod installs use CryptoSwift 0.5.2
4. Verify both still build and unit tests pass.
5. Run ```./smithy.sh```
6. Verify that library validation is run and passes

---

Please Review: @Workiva/mobile  