### PR TITLE
MOBILE-2157 RELEASE w-mobile-kit 1.0.0

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - SDWebImage/Core (= 3.8.0)
   - SDWebImage/Core (3.8.0)
   - SnapKit (0.20.0)
-  - WMobileKit (0.0.6):
+  - WMobileKit (1.0.0):
     - CryptoSwift (= 0.5.2)
     - SDWebImage (= 3.8)
     - SnapKit (= 0.20.0)
@@ -20,7 +20,7 @@ SPEC CHECKSUMS:
   CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
   SDWebImage: 7d9fe229266696de91eadf840c77ca15efd4bbd2
   SnapKit: 5fce3c1bbbf1fbd31de9aa92f33eb9fa03f15650
-  WMobileKit: 66ddea5172f560a9b5b74eab2e1061c6450021ae
+  WMobileKit: 48ffcc978874052797feb471c9addd1a1edc9b32
 
 PODFILE CHECKSUM: fb0ddbcd40ed7b9c9487bbb0e366869765e5df23
 

--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.6</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.6</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '0.0.6'
+  s.version          = '1.0.0'
   s.summary          = 'Swift library containing various custom UI components to provide functionality outside of the default libraries.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/Workiva/w-mobile-kit'


### PR DESCRIPTION
Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w-mobile-kit 1.0.0 items =======

 MOBILE-2160  - Pin down mobile-kit dependencies in WMobileKit.podspec  - https://github.com/Workiva/w-mobile-kit/pull/85

======= end =======


---

Please Review: @Workiva/mobile  

