### PR TITLE
MOBILE-2163: WBanner title has bad padding if no left icon.

### DIFF
--- a/Example/WMobileKitExample/ModalViewExamplesVC.swift
+++ b/Example/WMobileKitExample/ModalViewExamplesVC.swift
@@ -416,7 +416,7 @@ public class ModalViewExamplesVC: WSideMenuContentVC {
 
         bottomBanner = WBannerView(rootView: view,
             titleMessage: "Bottom Banner Title",
-            titleIcon: UIImage(named: "alert"),
+            titleIcon: nil,
             bodyMessage: "Body. Banners can be dismissed on a timer.",
             bannerColor: UIColor(hex: 0x006400))
         bottomBanner!.delegate = self

--- a/Source/WBanner.swift
+++ b/Source/WBanner.swift
@@ -230,7 +230,7 @@ public class WBannerView: UIView {
             if (titleIconImageView.image != nil) {
                 make.left.equalTo(titleIconImageView.snp_right).offset(6)
             } else {
-                make.left.equalTo(self).offset(-BANNER_DEFAULT_RIGHT_PADDING)
+                make.left.equalTo(self).offset(BANNER_DEFAULT_RIGHT_PADDING)
             }
 
             if (rightIconImageView.image != nil) {


### PR DESCRIPTION
Description
---
A WBanner without the left icon has bad title padding.

What Was Changed
---
Fixed padding issue when there is no title icon in a WBanner

Testing
---
* Run example app, verify the bottom banner example (that no longer has a title icon) shows correct padding for the title

---

Please Review: @Workiva/mobile  