### PR TITLE
MOBILE-1822: "Pull to refresh" components need to be less sensitive to pulling.

### DIFF
--- a/Source/WSpinner.swift
+++ b/Source/WSpinner.swift
@@ -19,12 +19,16 @@
 import Foundation
 import UIKit
 
+public enum WSpinnerDirection: Equatable {
+    case Clockwise, CounterClockwise
+}
+
 public class WSpinner: UIControl {
     // MARK: - Properties
     public var backgroundLayer: CAShapeLayer = CAShapeLayer()
     public var progressLayer: CAShapeLayer = CAShapeLayer()
     public var iconLayer: CALayer = CALayer()
-
+    
     public var indeterminateSectionLength: CGFloat = 0.15 {
         didSet {
             if (indeterminate) {
@@ -32,66 +36,66 @@ public class WSpinner: UIControl {
             }
         }
     }
-
+    
     public var icon: UIImage? {
         didSet {
             iconLayer.contents = icon!.CGImage
-
+            
             setNeedsDisplayMainThread()
         }
     }
-
+    
     public var progressLineColor: UIColor = UIColor(hex: 0xffffff, alpha: 0.75) {
         didSet {
             progressLayer.strokeColor = progressLineColor.CGColor
-
+            
             setNeedsDisplayMainThread()
         }
     }
-
+    
     public var backgroundLineColor: UIColor = UIColor(hex: 0xbfe4ff, alpha: 0.45) {
         didSet {
             backgroundLayer.strokeColor = backgroundLineColor.CGColor
-
+            
             setNeedsDisplayMainThread()
         }
     }
-
+    
     public var lineWidth: CGFloat = 3 {
         didSet {
             progressLayer.lineWidth = lineWidth;
             backgroundLayer.lineWidth = lineWidth;
-
+            
             setNeedsDisplayMainThread()
         }
     }
-
+    
     public var progress: CGFloat = 0 {
         didSet {
             if (progress >= 1.0) {
                 progress = 1.0
             }
-
+            
             setNeedsDisplayMainThread()
         }
     }
-
+    
     public var indeterminate: Bool = false {
         didSet {
             if (oldValue == indeterminate) {
                 return
             }
-
+            
             if (indeterminate) {
                 progress = self.indeterminateSectionLength
-
+                
                 let rotationAnimation = CABasicAnimation(keyPath: "transform.rotation.z")
-                rotationAnimation.toValue = M_PI * 2
+                rotationAnimation.toValue = direction == .Clockwise ? M_PI * 2 : -M_PI * 2
                 rotationAnimation.duration = 1.4
                 rotationAnimation.cumulative = true
                 rotationAnimation.repeatCount = HUGE
                 rotationAnimation.removedOnCompletion = false
-
+                
                 backgroundLayer.addAnimation(rotationAnimation, forKey: "rotationAnimation")
                 progressLayer.addAnimation(rotationAnimation, forKey: "rotationAnimation")
             } else {
@@ -100,110 +104,121 @@ public class WSpinner: UIControl {
             }
         }
     }
-
+    
+    public var direction: WSpinnerDirection = .Clockwise {
+        didSet {
+            setNeedsDisplayMainThread()
+        }
+    }
+    
     // MARK: - Inits
     public convenience init() {
         self.init(frame: CGRectZero)
     }
-
+    
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-
+        
         commonInit()
     }
-
+    
     public override init(frame: CGRect) {
         super.init(frame: frame)
-
+        
         commonInit()
     }
-
+    
     private func commonInit() {
         backgroundColor = .clearColor()
         progressLayer.strokeColor = progressLineColor.CGColor
         backgroundLayer.strokeColor = backgroundLineColor.CGColor
-
+        
         setupBackgroundLayer()
         setupProgressLayer()
         setupIconLayer()
     }
-
+    
     private func setupBackgroundLayer() {
         backgroundLayer.frame = bounds
         backgroundLayer.fillColor = UIColor.clearColor().CGColor
         backgroundLayer.lineWidth = lineWidth
         backgroundLayer.lineCap = kCALineCapRound
-
+        
         if (backgroundLayer.superlayer != layer) {
-            layer.addSublayer(backgroundLayer)
+            layer.insertSublayer(backgroundLayer, atIndex: 0)
         }
     }
-
+    
     private func setupProgressLayer() {
         progressLayer.frame = bounds
         progressLayer.fillColor = UIColor.clearColor().CGColor
         progressLayer.lineWidth = lineWidth
         progressLayer.lineCap = kCALineCapRound
-
+        
         if (progressLayer.superlayer != layer) {
             layer.addSublayer(progressLayer)
         }
     }
-
+    
     private func setupIconLayer() {
         iconLayer.frame = bounds
-
+        
         if (iconLayer.superlayer != layer) {
             layer.addSublayer(iconLayer)
         }
     }
-
+    
     // MARK: - Drawing
     public func setNeedsDisplayMainThread() {
         dispatch_async(dispatch_get_main_queue()) {
             self.setNeedsDisplay()
         }
     }
-
+    
     public override func drawRect(rect: CGRect) {
         backgroundLayer.frame = bounds
         progressLayer.frame = bounds
         iconLayer.frame = bounds
-
+        
         drawBackgroundCircle()
         drawProgress()
     }
-
+    
     public func drawBackgroundCircle() {
         backgroundLayer.strokeStart = 0
-        backgroundLayer.strokeEnd = 1 - progress
-
+        backgroundLayer.strokeEnd = 1
+        
         backgroundLayer.path = circlePath(true)
     }
-
+    
     public func drawProgress() {
         progressLayer.strokeStart = 0
         progressLayer.strokeEnd = progress
-
+        
         progressLayer.path = circlePath(false)
     }
-
+    
+    public func degressToRadians(degress: CGFloat) -> CGFloat {
+        return (CGFloat(M_PI) * degress) / CGFloat(180)
+    }
+    
     private func circlePath(backgroundPath: Bool) -> CGPath {
-        let startAngle = -CGFloat(M_PI / 2)
-        let endAngle = CGFloat(2 * M_PI) + startAngle
+        let isClockwise = direction == .Clockwise
+        let startAngle = CGFloat(3 * M_PI / 2)
+        let endAngle = isClockwise ? startAngle + CGFloat(2 * M_PI) : startAngle - CGFloat(2 * M_PI)
         let center = CGPointMake(bounds.size.width / 2, bounds.size.height / 2)
         let radius = (bounds.size.width - lineWidth) / 2
-
+        
         var path: UIBezierPath?
-
+        
         if backgroundPath {
-            path = UIBezierPath(arcCenter: center, radius: radius, startAngle: endAngle, endAngle: startAngle, clockwise: !backgroundPath)
+            path = UIBezierPath(arcCenter: center, radius: radius, startAngle: startAngle, endAngle: endAngle, clockwise: isClockwise)
         } else {
-            path = UIBezierPath(arcCenter: center, radius: radius, startAngle: startAngle, endAngle: endAngle, clockwise: !backgroundPath)
+            path = UIBezierPath(arcCenter: center, radius: radius, startAngle: startAngle, endAngle: endAngle, clockwise: isClockwise)
         }
-
+        
         path!.lineCapStyle = .Round
-
+        
         return path!.CGPath
     }
 }

--- a/Source/WSpinner.swift
+++ b/Source/WSpinner.swift
@@ -198,10 +198,6 @@ public class WSpinner: UIControl {
         progressLayer.path = circlePath(false)
     }
 
-    public func degressToRadians(degress: CGFloat) -> CGFloat {
-        return (CGFloat(M_PI) * degress) / CGFloat(180)
-    }
-
     private func circlePath(backgroundPath: Bool) -> CGPath {
         let isClockwise = direction == .Clockwise
         let startAngle = CGFloat(3 * M_PI / 2)

--- a/Source/WSpinner.swift
+++ b/Source/WSpinner.swift
@@ -28,7 +28,7 @@ public class WSpinner: UIControl {
     public var backgroundLayer: CAShapeLayer = CAShapeLayer()
     public var progressLayer: CAShapeLayer = CAShapeLayer()
     public var iconLayer: CALayer = CALayer()
-    
+
     public var indeterminateSectionLength: CGFloat = 0.15 {
         didSet {
             if (indeterminate) {
@@ -36,66 +36,66 @@ public class WSpinner: UIControl {
             }
         }
     }
-    
+
     public var icon: UIImage? {
         didSet {
             iconLayer.contents = icon!.CGImage
-            
+
             setNeedsDisplayMainThread()
         }
     }
-    
+
     public var progressLineColor: UIColor = UIColor(hex: 0xffffff, alpha: 0.75) {
         didSet {
             progressLayer.strokeColor = progressLineColor.CGColor
-            
+
             setNeedsDisplayMainThread()
         }
     }
-    
+
     public var backgroundLineColor: UIColor = UIColor(hex: 0xbfe4ff, alpha: 0.45) {
         didSet {
             backgroundLayer.strokeColor = backgroundLineColor.CGColor
-            
+
             setNeedsDisplayMainThread()
         }
     }
-    
+
     public var lineWidth: CGFloat = 3 {
         didSet {
             progressLayer.lineWidth = lineWidth;
             backgroundLayer.lineWidth = lineWidth;
-            
+
             setNeedsDisplayMainThread()
         }
     }
-    
+
     public var progress: CGFloat = 0 {
         didSet {
             if (progress >= 1.0) {
                 progress = 1.0
             }
-            
+
             setNeedsDisplayMainThread()
         }
     }
-    
+
     public var indeterminate: Bool = false {
         didSet {
             if (oldValue == indeterminate) {
                 return
             }
-            
+
             if (indeterminate) {
                 progress = self.indeterminateSectionLength
-                
+
                 let rotationAnimation = CABasicAnimation(keyPath: "transform.rotation.z")
                 rotationAnimation.toValue = direction == .Clockwise ? M_PI * 2 : -M_PI * 2
                 rotationAnimation.duration = 1.4
                 rotationAnimation.cumulative = true
                 rotationAnimation.repeatCount = HUGE
                 rotationAnimation.removedOnCompletion = false
-                
+
                 backgroundLayer.addAnimation(rotationAnimation, forKey: "rotationAnimation")
                 progressLayer.addAnimation(rotationAnimation, forKey: "rotationAnimation")
             } else {
@@ -104,121 +104,121 @@ public class WSpinner: UIControl {
             }
         }
     }
-    
+
     public var direction: WSpinnerDirection = .Clockwise {
         didSet {
             setNeedsDisplayMainThread()
         }
     }
-    
+
     // MARK: - Inits
     public convenience init() {
         self.init(frame: CGRectZero)
     }
-    
+
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        
+
         commonInit()
     }
-    
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         commonInit()
     }
-    
+
     private func commonInit() {
         backgroundColor = .clearColor()
         progressLayer.strokeColor = progressLineColor.CGColor
         backgroundLayer.strokeColor = backgroundLineColor.CGColor
-        
+
         setupBackgroundLayer()
         setupProgressLayer()
         setupIconLayer()
     }
-    
+
     private func setupBackgroundLayer() {
         backgroundLayer.frame = bounds
         backgroundLayer.fillColor = UIColor.clearColor().CGColor
         backgroundLayer.lineWidth = lineWidth
         backgroundLayer.lineCap = kCALineCapRound
-        
+
         if (backgroundLayer.superlayer != layer) {
             layer.insertSublayer(backgroundLayer, atIndex: 0)
         }
     }
-    
+
     private func setupProgressLayer() {
         progressLayer.frame = bounds
         progressLayer.fillColor = UIColor.clearColor().CGColor
         progressLayer.lineWidth = lineWidth
         progressLayer.lineCap = kCALineCapRound
-        
+
         if (progressLayer.superlayer != layer) {
             layer.addSublayer(progressLayer)
         }
     }
-    
+
     private func setupIconLayer() {
         iconLayer.frame = bounds
-        
+
         if (iconLayer.superlayer != layer) {
             layer.addSublayer(iconLayer)
         }
     }
-    
+
     // MARK: - Drawing
     public func setNeedsDisplayMainThread() {
         dispatch_async(dispatch_get_main_queue()) {
             self.setNeedsDisplay()
         }
     }
-    
+
     public override func drawRect(rect: CGRect) {
         backgroundLayer.frame = bounds
         progressLayer.frame = bounds
         iconLayer.frame = bounds
-        
+
         drawBackgroundCircle()
         drawProgress()
     }
-    
+
     public func drawBackgroundCircle() {
         backgroundLayer.strokeStart = 0
         backgroundLayer.strokeEnd = 1
-        
+
         backgroundLayer.path = circlePath(true)
     }
-    
+
     public func drawProgress() {
         progressLayer.strokeStart = 0
         progressLayer.strokeEnd = progress
-        
+
         progressLayer.path = circlePath(false)
     }
-    
+
     public func degressToRadians(degress: CGFloat) -> CGFloat {
         return (CGFloat(M_PI) * degress) / CGFloat(180)
     }
-    
+
     private func circlePath(backgroundPath: Bool) -> CGPath {
         let isClockwise = direction == .Clockwise
         let startAngle = CGFloat(3 * M_PI / 2)
         let endAngle = isClockwise ? startAngle + CGFloat(2 * M_PI) : startAngle - CGFloat(2 * M_PI)
         let center = CGPointMake(bounds.size.width / 2, bounds.size.height / 2)
         let radius = (bounds.size.width - lineWidth) / 2
-        
+
         var path: UIBezierPath?
-        
+
         if backgroundPath {
             path = UIBezierPath(arcCenter: center, radius: radius, startAngle: startAngle, endAngle: endAngle, clockwise: isClockwise)
         } else {
             path = UIBezierPath(arcCenter: center, radius: radius, startAngle: startAngle, endAngle: endAngle, clockwise: isClockwise)
         }
-        
+
         path!.lineCapStyle = .Round
-        
+
         return path!.CGPath
     }
 }

--- a/Tests/WSpinnerTests.swift
+++ b/Tests/WSpinnerTests.swift
@@ -28,8 +28,6 @@ class WSpinnerTests: QuickSpec {
 
             let whiteColor: UIColor = UIColor(hex: 0xffffff, alpha: 0.75)
             let greyColor: UIColor = UIColor(hex: 0xbfe4ff, alpha: 0.45)
-            let startAngle = -CGFloat(M_PI / 2)
-            let endAngle = CGFloat(2 * M_PI) + startAngle
 
             beforeEach({
                 subject = UIViewController()
@@ -86,12 +84,15 @@ class WSpinnerTests: QuickSpec {
                     // Icon layer should be configured correctly following drawing
                     expect(iLayer.frame) == spinnerView.bounds
                     expect(spinnerView.progress) == 0
+                    
+                    let startAngle = CGFloat(3 * M_PI / 2)
+                    let endAngle = CGFloat(2 * M_PI) + startAngle
 
                     // Background layer should be configured correctly following drawing
                     expect(bLayer.frame) == spinnerView.bounds
                     let bCenter = CGPointMake(spinnerView.bounds.size.width / 2, spinnerView.bounds.size.height / 2)
                     let bRadius = (spinnerView.bounds.size.width - 3) / 2
-                    expect(bLayer.path) == UIBezierPath(arcCenter: bCenter, radius: bRadius, startAngle: endAngle, endAngle: startAngle, clockwise: false).CGPath
+                    expect(bLayer.path) == UIBezierPath(arcCenter: bCenter, radius: bRadius, startAngle: startAngle, endAngle: endAngle, clockwise: true).CGPath
                     expect(bLayer.strokeEnd) == 1
 
                     // Progress layer should be configured correctly following drawing
@@ -157,13 +158,16 @@ class WSpinnerTests: QuickSpec {
                     // Icon layer should be configured correctly following drawing
                     expect(iLayer.frame) == spinnerView.bounds
                     expect(spinnerView.progress) == 0.15 // indeterminate progress set to 0.15
+                    
+                    let startAngle = CGFloat(3 * M_PI / 2)
+                    let endAngle = CGFloat(2 * M_PI) + startAngle
 
                     // Background layer should be configured correctly following drawing
                     expect(bLayer.frame) == spinnerView.bounds
                     let bCenter = CGPointMake(spinnerView.bounds.size.width / 2, spinnerView.bounds.size.height / 2)
                     let bRadius = (spinnerView.bounds.size.width - 3) / 2
-                    expect(bLayer.path) == UIBezierPath(arcCenter: bCenter, radius: bRadius, startAngle: endAngle, endAngle: startAngle, clockwise: false).CGPath
-                    expect(bLayer.strokeEnd) == 1 - 0.15
+                    expect(bLayer.path) == UIBezierPath(arcCenter: bCenter, radius: bRadius, startAngle: startAngle, endAngle: endAngle, clockwise: true).CGPath
+                    expect(bLayer.strokeEnd) == 1
 
                     // Progress layer should be configured correctly following drawing
                     expect(pLayer.frame) == spinnerView.bounds
@@ -182,6 +186,7 @@ class WSpinnerTests: QuickSpec {
 
                 it("should successfully add and display a progress spinner view with custom settings") {
                     spinnerView = WSpinner()
+                    spinnerView.direction = .CounterClockwise
                     spinnerView.indeterminate = true // Should be overridden by progress
                     spinnerView.progress = 0.25
                     spinnerView.backgroundColor = .whiteColor()
@@ -226,19 +231,22 @@ class WSpinnerTests: QuickSpec {
                     // Icon layer should be configured correctly following drawing
                     expect(iLayer.frame) == spinnerView.bounds
                     expect(spinnerView.progress) == 0.25
+                    
+                    let startAngle = CGFloat(3 * M_PI / 2)
+                    let endAngle = startAngle - CGFloat(2 * M_PI)
 
                     // Background layer should be configured correctly following drawing
                     expect(bLayer.frame) == spinnerView.bounds
                     let bCenter = CGPointMake(spinnerView.bounds.size.width / 2, spinnerView.bounds.size.height / 2)
                     let bRadius = (spinnerView.bounds.size.width - 1) / 2
-                    expect(bLayer.path) == UIBezierPath(arcCenter: bCenter, radius: bRadius, startAngle: endAngle, endAngle: startAngle, clockwise: false).CGPath
-                    expect(bLayer.strokeEnd) == 1 - 0.25
+                    expect(bLayer.path) == UIBezierPath(arcCenter: bCenter, radius: bRadius, startAngle: startAngle, endAngle: endAngle, clockwise: false).CGPath
+                    expect(bLayer.strokeEnd) == 1
 
                     // Progress layer should be configured correctly following drawing
                     expect(pLayer.frame) == spinnerView.bounds
                     let pCenter = CGPointMake(spinnerView.bounds.size.width / 2, spinnerView.bounds.size.height / 2)
                     let pRadius = (spinnerView.bounds.size.width - 1) / 2
-                    expect(pLayer.path) == UIBezierPath(arcCenter: pCenter, radius: pRadius, startAngle: startAngle, endAngle: endAngle, clockwise: true).CGPath
+                    expect(pLayer.path) == UIBezierPath(arcCenter: pCenter, radius: pRadius, startAngle: startAngle, endAngle: endAngle, clockwise: false).CGPath
                     expect(pLayer.strokeEnd) == 0.25
                 }
 


### PR DESCRIPTION
[PullToRefresh CR](https://github.com/Workiva/PullToRefresh/pull/1)
[Wdesk-ios CR](https://github.com/Workiva/wdesk-ios/pull/1231)

Description
---
- "Pull to refresh" components need to be less sensitive to pulling.

What Was Changed
---
- Forked the `PullToRefresh` repo and added a `refreshingOffset` which increases the amount of you have to pull the table view to get the refresh to trigger by the height of the refresh view plus the new offset value.
- Added a direction to the `WSpinner` that will allow it to draw clockwise or counterclockwise.
- Inverted the colors of the background and the progress stroke layer of the `WSpinner` use in the `WPullToRefresh` and the indeterminate is now `0.85` instead of `0.15`. These changes are for allowing the stroke of the circle while pulling a scroll view to be green instead of grey.
- Changes to update us to the latest version of the `PullToRefresh` component.

Testing
---
Follow testing instructions in `Wdesk-ios` CR.

---

Please Review: @Workiva/mobile  
