### PR TITLE
[MOBILE-2175] Update AutoCompleteTextView to support AttributedStrings

### DIFF
--- a/Source/WAutoCompleteTextView.swift
+++ b/Source/WAutoCompleteTextView.swift
@@ -292,11 +292,11 @@ public class WAutoCompleteTextView: UIView {
     public func acceptAutoCompletionWithAttributedString(attributedString: NSAttributedString) {
         var replaceText = attributedString
 
-        if let range = autoCompleteRange {
+        if var range = autoCompleteRange {
             var selection = textView.selectedTextRange
 
             if (!replacesControlPrefix) {
-                autoCompleteRange = range.startIndex.advancedBy(1)..<range.endIndex
+                range = range.startIndex.advancedBy(1)..<range.endIndex
             }
 
             if (addSpaceAfterReplacement) {

--- a/Source/WAutoCompleteTextView.swift
+++ b/Source/WAutoCompleteTextView.swift
@@ -304,16 +304,14 @@ public class WAutoCompleteTextView: UIView {
                     let attributedSuffix = NSMutableAttributedString(string: " ")
 
                     attributedSuffix.addAttribute(NSFontAttributeName,
-                                                  value: textView.font!,
-                                                  range: NSRange(
-                                                    location:0,
-                                                    length:attributedSuffix.length))
+                        value: textView.font!,
+                        range: NSRange(location:0,
+                                length:attributedSuffix.length))
 
                     attributedSuffix.addAttribute(NSForegroundColorAttributeName,
-                                                  value: textView.textColor!,
-                                                  range: NSRange(
-                                                    location:0,
-                                                    length:attributedSuffix.length))
+                        value: textView.textColor!,
+                        range: NSRange(location:0,
+                                length:attributedSuffix.length))
 
                     mutableCopy.appendAttributedString(attributedSuffix)
                     replaceText = mutableCopy
@@ -325,7 +323,6 @@ public class WAutoCompleteTextView: UIView {
             let location = currentText.startIndex.distanceTo(range.startIndex)
             let length = range.startIndex.distanceTo(range.endIndex)
             let ns = NSMakeRange(location, length)
-
 
             if let mutableCopy = textView.attributedText.mutableCopy() as? NSMutableAttributedString {
                 mutableCopy.replaceCharactersInRange(ns, withAttributedString: replaceText)
@@ -354,7 +351,6 @@ public class WAutoCompleteTextView: UIView {
             }
         }
     }
-
 
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self)

--- a/Source/WAutoCompleteTextView.swift
+++ b/Source/WAutoCompleteTextView.swift
@@ -286,37 +286,11 @@ public class WAutoCompleteTextView: UIView {
     }
 
     public func acceptAutoCompletionWithString(string: String) {
-        var replaceText = string
-
-        if let range = autoCompleteRange {
-            var selection = textView.selectedTextRange
-
-            if (!replacesControlPrefix) {
-                autoCompleteRange = range.startIndex.advancedBy(1)..<range.endIndex
-            }
-
-            if (addSpaceAfterReplacement) {
-                replaceText = replaceText.stringByAppendingString(" ")
-            }
-            textView.text?.replaceRange(autoCompleteRange!, with: replaceText)
-
-            let autoCompleteOffset = textView.text!.startIndex.distanceTo(range.startIndex) + 1
-
-            if let newSelectPos = textView.positionFromPosition(textView.beginningOfDocument, offset: autoCompleteOffset + replaceText.characters.count) {
-                selection = textView.textRangeFromPosition(newSelectPos, toPosition: newSelectPos)
-                textView.selectedTextRange = selection
-            }
-        } else {
-            if (addSpaceAfterReplacement) {
-                replaceText = replaceText.stringByAppendingString(" ")
-            }
-
-            textView.text = textView.text.stringByAppendingString(replaceText)
-        }
+        acceptAutoCompletionWithAttributedString(NSAttributedString(string: string))
     }
 
-    public func acceptAutoCompletionWithString(string: NSAttributedString) {
-        var replaceText = string
+    public func acceptAutoCompletionWithAttributedString(attributedString: NSAttributedString) {
+        var replaceText = attributedString
 
         if let range = autoCompleteRange {
             var selection = textView.selectedTextRange
@@ -330,13 +304,13 @@ public class WAutoCompleteTextView: UIView {
                     let attributedSuffix = NSMutableAttributedString(string: " ")
 
                     attributedSuffix.addAttribute(NSFontAttributeName,
-                                                  value: textView.font,
+                                                  value: textView.font!,
                                                   range: NSRange(
                                                     location:0,
                                                     length:attributedSuffix.length))
 
                     attributedSuffix.addAttribute(NSForegroundColorAttributeName,
-                                                  value: textView.textColor,
+                                                  value: textView.textColor!,
                                                   range: NSRange(
                                                     location:0,
                                                     length:attributedSuffix.length))

--- a/Source/WAutoCompleteTextView.swift
+++ b/Source/WAutoCompleteTextView.swift
@@ -315,6 +315,73 @@ public class WAutoCompleteTextView: UIView {
         }
     }
 
+    public func acceptAutoCompletionWithString(string: NSAttributedString) {
+        var replaceText = string
+
+        if let range = autoCompleteRange {
+            var selection = textView.selectedTextRange
+
+            if (!replacesControlPrefix) {
+                autoCompleteRange = range.startIndex.advancedBy(1)..<range.endIndex
+            }
+
+            if (addSpaceAfterReplacement) {
+                if let mutableCopy = replaceText.mutableCopy() as? NSMutableAttributedString {
+                    let attributedSuffix = NSMutableAttributedString(string: " ")
+
+                    attributedSuffix.addAttribute(NSFontAttributeName,
+                                                  value: textView.font,
+                                                  range: NSRange(
+                                                    location:0,
+                                                    length:attributedSuffix.length))
+
+                    attributedSuffix.addAttribute(NSForegroundColorAttributeName,
+                                                  value: textView.textColor,
+                                                  range: NSRange(
+                                                    location:0,
+                                                    length:attributedSuffix.length))
+
+                    mutableCopy.appendAttributedString(attributedSuffix)
+                    replaceText = mutableCopy
+                }
+            }
+
+            let currentText = textView.text
+
+            let location = currentText.startIndex.distanceTo(range.startIndex)
+            let length = range.startIndex.distanceTo(range.endIndex)
+            let ns = NSMakeRange(location, length)
+
+
+            if let mutableCopy = textView.attributedText.mutableCopy() as? NSMutableAttributedString {
+                mutableCopy.replaceCharactersInRange(ns, withAttributedString: replaceText)
+
+                textView.attributedText = mutableCopy
+
+                let autoCompleteOffset = textView.text!.startIndex.distanceTo(range.startIndex) + 1
+
+                if let newSelectPos = textView.positionFromPosition(textView.beginningOfDocument, offset: autoCompleteOffset + replaceText.length) {
+                    selection = textView.textRangeFromPosition(newSelectPos, toPosition: newSelectPos)
+                    textView.selectedTextRange = selection
+                }
+            }
+
+        } else {
+            if (addSpaceAfterReplacement) {
+                if let mutableCopy = replaceText.mutableCopy() as? NSMutableAttributedString {
+                    mutableCopy.appendAttributedString(NSAttributedString(string: " "))
+                    replaceText = mutableCopy
+                }
+            }
+            
+            if let mutableCopy = textView.attributedText.mutableCopy() as? NSMutableAttributedString {
+                mutableCopy.appendAttributedString(replaceText)
+                textView.attributedText = mutableCopy
+            }
+        }
+    }
+
+
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self)
     }

--- a/Source/WTextView.swift
+++ b/Source/WTextView.swift
@@ -39,6 +39,12 @@ public class WTextView: UITextView, UITextViewDelegate {
             textDidChange()
         }
     }
+
+    override public var attributedText: NSAttributedString! {
+        didSet {
+            textDidChange()
+        }
+    }
         
     public var placeholderText: String = "" {
         didSet {


### PR DESCRIPTION
[Connected wdesk-ios CR](https://github.com/Workiva/wdesk-ios/pull/1238)

Description
---
- Update AutoCompleteTextView to work with color-defined mentions by allowing it to accept changes in the form of Attributed Strings

What Was Changed
---
- Added a second method for accepting attributed strings, as well as ensuring that textdidchange is triggered on attributedtext changes.

Testing
---
- Ensure that when using the AutoCompleteTextView in a situation that makes use of attributed strings, the proper attributes (colors, font, so forth) come through as expected, such as when inserted user mentions. 

---

Please Review: @Workiva/mobile  

