### PR TITLE
MOBILE-2165 Release w-mobile-kit 2.0.1

### DIFF
--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '2.0.0'
+  s.version          = '2.0.1'
   s.summary          = 'Swift library containing various custom UI components to provide functionality outside of the default libraries.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/Workiva/w-mobile-kit'


### PR DESCRIPTION

Pulls Included in Release:
* [MOBILE-1822: "Pull to refresh" components need to be less sensitive to pulling.](https://github.com/Workiva/w-mobile-kit/pull/94)
* [MOBILE-2119: Flag to WSwitch that controls sending ValueChanged event](https://github.com/Workiva/w-mobile-kit/pull/95)


Requested by: charliekump-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w-mobile-kit/compare/2.0.0...version-bump-w-mobile-kit-2-0-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w-mobile-kit/compare/2.0.0...2.0.1