### PR TITLE
MOBILE-2197: Add accessibility identifier to the side menu button

### DIFF
--- a/Source/WSideMenuVC.swift
+++ b/Source/WSideMenuVC.swift
@@ -381,6 +381,8 @@ public class WSideMenuContentVC: WSizeVC, WSideMenuProtocol {
                     action: #selector(WSideMenuContentVC.toggleSideMenu))
             }
 
+            sideMenuButtonItem.accessibilityIdentifier = "SideMenuButton"
+
             if (navigationController?.viewControllers.count > 1 && navigationController?.topViewController == self) {
                 var backMenuButtonItem = UIBarButtonItem()
 


### PR DESCRIPTION
Description
---
The side menu button did not have an accessibility identifier causing automation tests to be difficult if the icon changes

What Was Changed
---
Added accessibility identifier to the side menu button

Testing
---
* Ensure unit tests continue to pass

---

Please Review: @Workiva/mobile  