### PR TITLE
[MOBILE-2104] Clean up last lint warning.

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - SDWebImage/Core (= 3.8.0)
   - SDWebImage/Core (3.8.0)
   - SnapKit (0.22.0)
-  - WMobileKit (2.0.2):
+  - WMobileKit (2.0.3):
     - CryptoSwift (= 0.5.2)
     - SDWebImage (= 3.8)
     - SnapKit (= 0.22.0)
@@ -20,7 +20,7 @@ SPEC CHECKSUMS:
   CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
   SDWebImage: 7d9fe229266696de91eadf840c77ca15efd4bbd2
   SnapKit: 0dd2fd157330f1ea11fd84da13e6be8a7a22bae0
-  WMobileKit: 30fdb39c34eaf5e188aae55cd0a8dcb8a7648c93
+  WMobileKit: 81f6d3047803e35c8b3881d69608311c7013844f
 
 PODFILE CHECKSUM: 22b307ad95a73c481740aba61043b1ced16873a0
 

--- a/Source/WUserLogoView.swift
+++ b/Source/WUserLogoView.swift
@@ -170,7 +170,7 @@ public class WUserLogoView: UIView {
     }
 
     private func setupImage() {
-        if let profileImage = image {
+        if (image != nil) {
             initialsLabel.hidden = true
             profileImageView.hidden = false
 


### PR DESCRIPTION
Description
---
When running `pod lib lint` in Mobile Kit it won't release with compiler warnings unless a force flag is set. There are 4 warnings at time of this ticket creation. These should all be able to be addressed.

What Was Changed
---
* There was just one left, so I changed it to a nil check.
```
 -> WMobileKit (2.0.3)
    - WARN  | xcodebuild:  /Users/jeffscaturro/workspaces/wf/w-mobile-kit/Source/WUserLogoView.swift:173:16: warning: value 'profileImage' was defined but never used; consider replacing with boolean test
```

Testing
---
- [x] `pod lib lint` should work.
- [x] unit tests pass (smithy).
- [x] User logo view regression testing.

---

Please Review: @Workiva/mobile  

