### PR TITLE
MOBILE-2247 Release w-mobile-kit 2.0.4

### DIFF
--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.3</string>
+	<string>2.0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.3</string>
+	<string>2.0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '2.0.3'
+  s.version          = '2.0.4'
   s.summary          = 'Swift library containing various custom UI components to provide functionality outside of the default libraries.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/Workiva/w-mobile-kit'


### PR DESCRIPTION

Pulls Included in Release:
* [[MOBILE-2104] Clean up last lint warning.](https://github.com/Workiva/w-mobile-kit/pull/102)
* [Readme_gifs: Added gifs to demo components and descriptions](https://github.com/Workiva/w-mobile-kit/pull/103)
* [[RED-659] Add Aviary.yaml](https://github.com/Workiva/w-mobile-kit/pull/104)
* [MOBILE-2253: Allow page to be set programmatically](https://github.com/Workiva/w-mobile-kit/pull/105)


Requested by: @charliekump-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w-mobile-kit/compare/2.0.3...version-bump-w-mobile-kit-2-0-4
Diff Between Last Tag and New Tag: https://github.com/Workiva/w-mobile-kit/compare/2.0.3...2.0.4