### PR TITLE
[MOBILE-2342] Panel should have minimum height to snap to

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - SDWebImage/Core (= 3.8.0)
   - SDWebImage/Core (3.8.0)
   - SnapKit (0.22.0)
-  - WMobileKit (2.0.3):
+  - WMobileKit (2.1.2):
     - CryptoSwift (= 0.5.2)
     - SDWebImage (= 3.8)
     - SnapKit (= 0.22.0)
@@ -14,13 +14,13 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   WMobileKit:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
   SDWebImage: 7d9fe229266696de91eadf840c77ca15efd4bbd2
   SnapKit: 0dd2fd157330f1ea11fd84da13e6be8a7a22bae0
-  WMobileKit: 81f6d3047803e35c8b3881d69608311c7013844f
+  WMobileKit: 9b466fafd463b01be99bab5fbe795e98ef6232f1
 
 PODFILE CHECKSUM: 22b307ad95a73c481740aba61043b1ced16873a0
 

--- a/Example/WMobileKitExample/PanelExample.swift
+++ b/Example/WMobileKitExample/PanelExample.swift
@@ -31,6 +31,8 @@ public class PanelExampleVC: WPagingPanelVC {
 
         floatingButton.icon = UIImage(named: "drawer")
 
+        minimumSnapHeight = 240
+
         pages = [panelContent1, panelContent2, panelContent3]
 
         let outerContentVC = OuterContentVC()
@@ -47,15 +49,40 @@ class PanelContentVC: WSideMenuContentVC, UITableViewDelegate, UITableViewDataSo
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let tableView = UITableView()
-        tableView.delegate = self
-        tableView.dataSource = self
-        tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: "tableCell")
+        if (contentType < 2) {
+            let tableView = UITableView()
+            tableView.delegate = self
+            tableView.dataSource = self
+            tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: "tableCell")
 
-        view.addSubview(tableView)
+            view.addSubview(tableView)
 
-        tableView.snp_makeConstraints { (make) in
-            make.edges.equalTo(view)
+            tableView.snp_makeConstraints { (make) in
+                make.edges.equalTo(view)
+            }
+        } else {
+            let colorView = UIView()
+            colorView.backgroundColor = UIColor.blueColor().colorWithAlphaComponent(0.6)
+            view.addSubview(colorView)
+
+            let label = UILabel()
+            label.text = "This view has a set height, so we need a minimum height for smaller screen sizes"
+            label.numberOfLines = 0
+            label.lineBreakMode = .ByWordWrapping
+            label.textColor = .whiteColor()
+            label.font = .boldSystemFontOfSize(18)
+            label.textAlignment = .Center
+            colorView.addSubview(label)
+
+
+            colorView.snp_makeConstraints { (make) in
+                make.left.top.right.width.equalTo(view).inset(20)
+                make.height.equalTo(180)
+            }
+
+            label.snp_makeConstraints { (make) in
+                make.edges.equalTo(colorView).inset(8)
+            }
         }
     }
 

--- a/Source/WFAButton.swift
+++ b/Source/WFAButton.swift
@@ -114,8 +114,8 @@ public class WFAButton: UIControl {
         layoutIfNeeded()
 
         if (hasShadow) {
-            var nonShadowLayer = buttonBackgroundView.hidden ? buttonBackgroundView.layer : imageView.layer
-            var shadowLayer = buttonBackgroundView.hidden ? imageView.layer : buttonBackgroundView.layer
+            let nonShadowLayer = buttonBackgroundView.hidden ? buttonBackgroundView.layer : imageView.layer
+            let shadowLayer = buttonBackgroundView.hidden ? imageView.layer : buttonBackgroundView.layer
 
             shadowLayer.masksToBounds = false
             shadowLayer.shadowOpacity = 0.5

--- a/Source/WPanel.swift
+++ b/Source/WPanel.swift
@@ -270,7 +270,12 @@ public class WPanelVC: WSideMenuContentVC {
             panelView.bottomDragLine.hidden = true
             panelView.layer.cornerRadius = 0
         } else {
-            currentPanelOffset = view.frame.height * currentPanelRatio
+            var offset = view.frame.height * currentPanelRatio
+            if let minimumSnapHeight = minimumSnapHeight where offset < minimumSnapHeight && offset > 0.0 {
+                offset = minimumSnapHeight
+            }
+
+            currentPanelOffset = offset
 
             contentContainerView.snp_remakeConstraints { (make) in
                 make.edges.equalTo(view)
@@ -482,6 +487,8 @@ public class WPanelVC: WSideMenuContentVC {
         // If side panel, set ratio as well in case we change back to vertical panel
         if (sidePanel) {
             currentPanelRatio = currentPanelOffset > 0.0 ? (getNextSnapRatio(getSmallestSnapRatio()) ?? getLargestSnapRatio()) : 0.0
+        } else {
+            currentPanelRatio = currentPanelOffset / view.frame.height
         }
 
         if (animated) {

--- a/Source/WPanel.swift
+++ b/Source/WPanel.swift
@@ -145,6 +145,9 @@ public class WPanelVC: WSideMenuContentVC {
     // Height Ratios for snapping, values can be any non-negative value where 1.0 equals full height of the view controller's view
     public var snapHeights: [CGFloat] = [0.0, 0.4, 0.96]
 
+    // Minimum height to snap to in case the screen height is too small for content you want to present
+    public var minimumSnapHeight: CGFloat?
+
     // Cap value on how far user can drag the panel up before it snaps back to heighest value in snapHeights
     // 0.0 means no "rubber band" effect, 1.0 means they can drag as far as they want until it snaps back
     public var springValuePastMaxHeight: CGFloat = 0.02
@@ -373,8 +376,14 @@ public class WPanelVC: WSideMenuContentVC {
                         closestSnapRatio = prevRatio
                     }
                 }
-                
-                movePanelToSnapRatio(closestSnapRatio!, animated: true)
+
+                // Verify the height is not smaller than the minimum height if set
+                let actualHeight = view.frame.height * closestSnapRatio!
+                if let minimumSnapHeight = minimumSnapHeight where closestSnapRatio! > 0.0 && actualHeight < minimumSnapHeight {
+                    movePanelToValue(minimumSnapHeight, animated: true)
+                } else {
+                    movePanelToSnapRatio(closestSnapRatio!, animated: true)
+                }
             }
         default:
             break
@@ -394,7 +403,15 @@ public class WPanelVC: WSideMenuContentVC {
             movePanelToValue(sidePanelWidth, animated: true)
         } else {
             // Move to 1st ratio above the smallest (which is typically 0.0), or the largest if there isn't one after the smallest
-            movePanelToSnapRatio(getNextSnapRatio(getSmallestSnapRatio()) ?? getLargestSnapRatio(), animated: true)
+            let snapRatio = getNextSnapRatio(getSmallestSnapRatio()) ?? getLargestSnapRatio()
+
+            // Verify the height is not smaller than the minimum height if set
+            let actualHeight = view.frame.height * snapRatio
+            if let minimumSnapHeight = minimumSnapHeight where actualHeight < minimumSnapHeight {
+                movePanelToValue(minimumSnapHeight, animated: true)
+            } else {
+                movePanelToSnapRatio(snapRatio, animated: true)
+            }
         }
     }
 

--- a/Tests/WPanelTests.swift
+++ b/Tests/WPanelTests.swift
@@ -236,6 +236,16 @@ class WPanelSpec: QuickSpec {
                     expect(subject.panelView.frame.origin.y) == subject.view.frame.height - 100
                     expect(subject.floatingButton.hidden) == true
                 }
+
+                it("should move to minimum height if needed") {
+                    subject.widthCapForSidePanel = CGFloat.max
+                    subject.minimumSnapHeight = 500
+
+                    subject.floatingButtonWasPressed(subject.floatingButton)
+
+                    expect(subject.panelView.frame.height) == 500 + subject.cornerRadius
+                    expect(subject.floatingButton.hidden) == true
+                }
             }
 
             describe("panel gestures") {
@@ -325,6 +335,20 @@ class WPanelSpec: QuickSpec {
                     subject.panelWasPanned(recognizer)
 
                     expect(subject.currentPanelRatio) == 0.0
+                }
+
+                it("should snap vertical panel to minimum height if needed") {
+                    subject.snapHeights = [0.0, 0.1]
+                    subject.widthCapForSidePanel = CGFloat.max
+                    subject.minimumSnapHeight = 500
+
+                    let recognizer = UIPanGestureRecognizerMock()
+                    recognizer.testState = .Ended
+                    recognizer.returnPoint = CGPointZero
+
+                    subject.panelWasPanned(recognizer)
+
+                    expect(subject.currentPanelOffset) == 500
                 }
 
                 it("should hide panel when tapped") {


### PR DESCRIPTION
Description
---
The panel in the viewer should have a minimum height to snap to

What Was Changed
---
Added minimum height property to WPanel in case panel content needs to be larger than what is typically shown on smaller screen sizes

Testing
---
* Run example app on small and large screen sizes
  - Verify the 3rd page on the Panel example always shows the entire content (AKA, the panel snaps to minimum height)
* Ensure unit tests pass

---

Please Review: @Workiva/mobile  