### PR TITLE
[MOBILE-2331] Release w-mobile-kit 2.1.3.

### DIFF
--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '2.1.2'
+  s.version          = '2.1.3'
   s.summary          = 'Swift library containing various custom UI components to provide functionality outside of the default libraries.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/Workiva/w-mobile-kit'


### PR DESCRIPTION
Pulls included in this release:
---
* [MOBILE-2355](https://jira.atl.workiva.net/browse/MOBILE-2355)  - Clicking into the "Add Support" text field does not slide the cert to show the text field while typing  - https://github.com/Workiva/w-mobile-kit/pull/115

* [MOBILE-2342](https://jira.atl.workiva.net/browse/MOBILE-2342)  - Panel should have minimum height to snap to  - https://github.com/Workiva/w-mobile-kit/pull/113

---

Please Review @Workiva/mobile 