### PR TITLE
Release w-mobile-kit 2.1.3

### DIFF
--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '2.1.2'
+  s.version          = '2.1.3'
   s.summary          = 'Swift library containing various custom UI components to provide functionality outside of the default libraries.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/Workiva/w-mobile-kit'


### PR DESCRIPTION

Pulls Included in Release:
* [MOBILE-2355: Increase Radiobutton performance for use in Certs](https://github.com/Workiva/w-mobile-kit/pull/115)
* [[MOBILE-2407] Adding a two line toast.](https://github.com/Workiva/w-mobile-kit/pull/116)
* [[MOBILE-2342] Panel should have minimum height to snap to](https://github.com/Workiva/w-mobile-kit/pull/113)


Requested by: @jeffscaturro-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w-mobile-kit/compare/2.1.2...version-bump-w-mobile-kit-2-1-3_1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w-mobile-kit/compare/2.1.2...2.1.3