### PR TITLE
RMCONS-5518 Consume smithy-runner 3.5.5

### DIFF
--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,5 +1,6 @@
 language: python
 
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner:112206
 before_install:
   - bundle install --path ~/.gem
   - rbenv rehash


### PR DESCRIPTION
In order to keep builds deterministic, and reduce the risk of future build failure, please pin your smithy runner to the currently defaulted runner.
For more information please see the email 'Smithy Runner Recommendation' or reach out to Travis Reed in hipchat.


Requested by: @travisreed-wf