### PR TITLE
Consume smithy-runner v3.6.1

### DIFF
--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,6 +1,6 @@
 language: python
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner:112206
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner:119015
 before_install:
   - bundle install --path ~/.gem
   - rbenv rehash


### PR DESCRIPTION

Pulls Included in Release:
* [DevTools-904 update smithy-runner to Release v3.6.1](https://github.com/Workiva/smithy-runner/pull/27)
