### PR TITLE
DEVTOOLS-957 Consume smithy-runner v3.6.2

### DIFF
--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,6 +1,6 @@
 language: python
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner:112206
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner:127520
 before_install:
   - bundle install --path ~/.gem
   - rbenv rehash


### PR DESCRIPTION

Pulls Included in Release:
* [DEVTOOLS-531: smithy builder updates](https://github.com/Workiva/smithy-runner/pull/29)
