### PR TITLE
[MOBILE-2425] Update constraints on constraint change.

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - SDWebImage/Core (= 3.8.0)
   - SDWebImage/Core (3.8.0)
   - SnapKit (0.22.0)
-  - WMobileKit (2.1.2):
+  - WMobileKit (2.1.4):
     - CryptoSwift (= 0.5.2)
     - SDWebImage (= 3.8)
     - SnapKit (= 0.22.0)
@@ -14,13 +14,13 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   WMobileKit:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
   SDWebImage: 7d9fe229266696de91eadf840c77ca15efd4bbd2
   SnapKit: 0dd2fd157330f1ea11fd84da13e6be8a7a22bae0
-  WMobileKit: 9b466fafd463b01be99bab5fbe795e98ef6232f1
+  WMobileKit: bc79f119a7061c45467d79f8babbf72d84a0a62e
 
 PODFILE CHECKSUM: 22b307ad95a73c481740aba61043b1ced16873a0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     nanaimo (0.2.3)
     nap (1.1.0)
     netrc (0.7.8)
+    ocunit2junit (1.4)
     plist (3.2.0)
     ruby-macho (0.2.6)
     rubyzip (1.1.7)
@@ -103,7 +104,8 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.2.0.beta.1)
+  ocunit2junit
   xcov (= 0.11.2)
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/Source/WPagingSelectorVC.swift
+++ b/Source/WPagingSelectorVC.swift
@@ -402,7 +402,7 @@ public class WPagingSelectorVC: WSideMenuContentVC, WPagingSelectorControlDelega
 
     public var pagingControlSidePadding: CGFloat = DEFAULT_PAGING_SELECTOR_SIDE_PADDING {
         didSet {
-            setupUI()
+            updatePagingSelectorConstraints()
         }
     }
 

--- a/Source/WPagingSelectorVC.swift
+++ b/Source/WPagingSelectorVC.swift
@@ -402,7 +402,7 @@ public class WPagingSelectorVC: WSideMenuContentVC, WPagingSelectorControlDelega
 
     public var pagingControlSidePadding: CGFloat = DEFAULT_PAGING_SELECTOR_SIDE_PADDING {
         didSet {
-            updatePagingSelectorConstraints()
+            pagingControlConstraintsChanged()
         }
     }
 
@@ -497,7 +497,7 @@ public class WPagingSelectorVC: WSideMenuContentVC, WPagingSelectorControlDelega
 
         pagingSelectorControl?.delegate = self
 
-        updatePagingSelectorConstraints()
+        pagingControlConstraintsChanged()
 
         if (pages.count > 0) {
             let newMainViewController = pages[0].viewController
@@ -507,7 +507,7 @@ public class WPagingSelectorVC: WSideMenuContentVC, WPagingSelectorControlDelega
         }
     }
 
-    public func updatePagingSelectorConstraints() {
+    public func pagingControlConstraintsChanged() {
         if let pagingSelectorControl = pagingSelectorControl {
             pagingSelectorControl.tabTextColor = tabTextColor
             pagingSelectorControl.separatorLineColor = separatorLineColor
@@ -527,10 +527,6 @@ public class WPagingSelectorVC: WSideMenuContentVC, WPagingSelectorControlDelega
                 make.top.equalTo(pagingSelectorControl.snp_bottom)
             }
         }
-    }
-
-    public func pagingControlConstraintsChanged() {
-        updatePagingSelectorConstraints()
     }
 
     // Delegate methods

--- a/Source/WPagingSelectorVC.swift
+++ b/Source/WPagingSelectorVC.swift
@@ -396,13 +396,13 @@ public class WPagingSelectorVC: WSideMenuContentVC, WPagingSelectorControlDelega
     public private(set) var pagingSelectorControl: WPagingSelectorControl?
     public var pagingControlHeight: CGFloat = DEFAULT_PAGING_SELECTOR_HEIGHT {
         didSet {
-            pagingControlConstraintsChanged()
+            setupUI()
         }
     }
 
     public var pagingControlSidePadding: CGFloat = DEFAULT_PAGING_SELECTOR_SIDE_PADDING {
         didSet {
-            pagingControlConstraintsChanged()
+            setupUI()
         }
     }
 
@@ -445,7 +445,7 @@ public class WPagingSelectorVC: WSideMenuContentVC, WPagingSelectorControlDelega
 
     public var tabWidth: CGFloat? {
         didSet {
-            pagingControlConstraintsChanged()
+            setupUI()
         }
     }
 
@@ -497,12 +497,23 @@ public class WPagingSelectorVC: WSideMenuContentVC, WPagingSelectorControlDelega
 
         pagingSelectorControl?.delegate = self
 
+        updatePagingSelectorConstraints()
+
+        if (pages.count > 0) {
+            let newMainViewController = pages[0].viewController
+            addViewControllerToContainer(mainContainerView, viewController: newMainViewController)
+
+            self.mainViewController = newMainViewController
+        }
+    }
+
+    public func updatePagingSelectorConstraints() {
         if let pagingSelectorControl = pagingSelectorControl {
             pagingSelectorControl.tabTextColor = tabTextColor
             pagingSelectorControl.separatorLineColor = separatorLineColor
 
             view.addSubview(pagingSelectorControl)
-            pagingSelectorControl.snp_makeConstraints { (make) in
+            pagingSelectorControl.snp_remakeConstraints { (make) in
                 make.left.equalTo(view).offset(pagingControlSidePadding)
                 make.right.equalTo(view).offset(-pagingControlSidePadding)
                 make.height.equalTo(pagingControlHeight)
@@ -516,17 +527,10 @@ public class WPagingSelectorVC: WSideMenuContentVC, WPagingSelectorControlDelega
                 make.top.equalTo(pagingSelectorControl.snp_bottom)
             }
         }
-
-        if (pages.count > 0) {
-            let newMainViewController = pages[0].viewController
-            addViewControllerToContainer(mainContainerView, viewController: newMainViewController)
-
-            self.mainViewController = newMainViewController
-        }
     }
 
     public func pagingControlConstraintsChanged() {
-        setupUI()
+        updatePagingSelectorConstraints()
     }
 
     // Delegate methods

--- a/Tests/WPagingSelectorVCTests.swift
+++ b/Tests/WPagingSelectorVCTests.swift
@@ -95,13 +95,6 @@ class WPagingSelectorVCSpec: QuickSpec {
                     
                     expect(selector!.superview).to(beNil())
                 }
-
-                it("should remove old paging selector when setting new side padding") {
-                    let selector = subject.pagingSelectorControl
-                    subject.pagingControlSidePadding = 10
-
-                    expect(selector!.superview).to(beNil())
-                }
                 
                 it("should set color on control when setting on the VC") {
                     subject.tabTextColor = .blueColor()


### PR DESCRIPTION
Description
---
View will reset when you change tabs:
```
1. Navigate from My Recent to the All Files tab in Wdesk mobile (note: this happens in Tasks, Certs, etc too)
2. Change to landscape mode
3. View resets to My Recents
```

I noticed a retain cycle in Wdesk (*slightly* difficult to reproduce, may have gotten it in a weirder state at first then noticed these steps to reproduce):
```
1. Start on All Files tab
2. Rotate
3. Tap Recent tab, tap All Files tab
4. Rotate
5. Repeat
6. The count will increase while doing this.
```

What Was Changed
---
We were calling `setupUI` again on rotate or size class events, where I believe we just needed to update the constraints. I did not notice any regressions using this approach but would like original author's eyes on it.
* I broke the SnapKit constraint part into a method and call that during `setupUI` resulting in no change in that method. 
* During variable getters, I replaced existing calls to `pagingControlConstraintsChanged` with `setupUI` since that is what we were calling before.
  * Except for when `pagingControlSidePadding` is set, this should update just the constraints, as it is not used in `setupUI`.
* Now when our delegates go through the chain of rotation/size class updates, it goes through `pagingControlConstraintsChanged` which updates the constraints. 

Testing
---
- [ ] You can use https://github.com/Workiva/wdesk-ios/pull/1354 to test this (it will also be the version bump to consume this change) (or example app).
- [ ] Verify tab persists through rotate (should not change back to the first).
- [ ] Verify you can not reproduce the retain cycle issue.

---

Please Review: @Workiva/mobile  
