### PR TITLE
DEVTOOLS-885 Consume smithy-runner 3.5.5

### DIFF
--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,6 +1,6 @@
 language: python
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner:112206
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner:111958
 before_install:
   - bundle install --path ~/.gem
   - rbenv rehash


### PR DESCRIPTION

Pulls Included in Release:
* [Update to drydock.workiva.net](https://github.com/Workiva/smithy-runner/pull/23)
* [DevTools-888 Install smithy-builder 3.5.5 Release v3.5.5](https://github.com/Workiva/smithy-runner/pull/24)
