### PR TITLE
MOBILE-2418 Release w-mobile-kit 2.1.5

### DIFF
--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.4</string>
+	<string>2.1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.4</string>
+	<string>2.1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '2.1.4'
+  s.version          = '2.1.5'
   s.summary          = 'Swift library containing various custom UI components to provide functionality outside of the default libraries.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/Workiva/w-mobile-kit'


### PR DESCRIPTION

Pulls Included in Release:
* [RMCONS-5518 Consume smithy-runner 3.5.5](https://github.com/Workiva/w-mobile-kit/pull/123)
* [[MOBILE-2425] Update constraints on constraint change.](https://github.com/Workiva/w-mobile-kit/pull/127)


Requested by: @brianblanchard-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w-mobile-kit/compare/2.1.4...version-bump-w-mobile-kit-2-1-5
Diff Between Last Tag and New Tag: https://github.com/Workiva/w-mobile-kit/compare/2.1.4...2.1.5