### PR TITLE
[MOBILE-2521] WRadioButton border selected v non-selected.

### DIFF
--- a/Source/WRadioButton.swift
+++ b/Source/WRadioButton.swift
@@ -54,7 +54,13 @@ public class WRadioButton: UIControl {
         }
     }
 
-    public var borderColor: UIColor = .lightGrayColor() {
+    public var borderColorNotSelected: UIColor = .lightGrayColor() {
+        didSet {
+            setupUI()
+        }
+    }
+
+    public var borderColorSelected: UIColor = .lightGrayColor() {
         didSet {
             setupUI()
         }
@@ -112,6 +118,7 @@ public class WRadioButton: UIControl {
             )
 
             if (oldValue != selected) {
+                updateUISelectedChanged()
                 sendActionsForControlEvents(.ValueChanged)
             }
         }
@@ -183,10 +190,10 @@ public class WRadioButton: UIControl {
 
         radioCircle.backgroundColor = buttonColor
         radioCircle.layer.borderWidth = borderWidth
-        radioCircle.layer.borderColor = borderColor.CGColor
 
-        indicatorView.alpha = selected ? 1.0 : 0.0
         indicatorView.backgroundColor = indicatorColor
+
+        updateUISelectedChanged()
 
         // Need to set the frame first or will result in square
         layoutIfNeeded()
@@ -195,6 +202,12 @@ public class WRadioButton: UIControl {
         indicatorView.layer.cornerRadius = indicatorView.frame.size.width / 2
 
         invalidateIntrinsicContentSize()
+    }
+
+    public func updateUISelectedChanged() {
+        radioCircle.layer.borderColor = selected ? borderColorSelected.CGColor : borderColorNotSelected.CGColor
+
+        indicatorView.alpha = selected ? 1.0 : 0.0
     }
 
     public func radioButtonSelected(notification: NSNotification) {

--- a/Tests/WRadioButtonTests.swift
+++ b/Tests/WRadioButtonTests.swift
@@ -52,7 +52,8 @@ class WRadioButtonSpec: QuickSpec {
                 expect(radioButton.buttonColor) == UIColor.whiteColor()
                 expect(radioButton.highlightColor) == UIColor.grayColor()
                 expect(radioButton.indicatorColor) == UIColor.darkGrayColor()
-                expect(radioButton.borderColor) == UIColor.lightGrayColor()
+                expect(radioButton.borderColorNotSelected) == UIColor.lightGrayColor()
+                expect(radioButton.borderColorSelected) == UIColor.lightGrayColor()
                 expect(radioButton.borderWidth) == 2.0
                 expect(radioButton.buttonRadius) == 12.0
                 expect(radioButton.indicatorRadius) == 6
@@ -116,7 +117,8 @@ class WRadioButtonSpec: QuickSpec {
                     radioButton.buttonColor = UIColor.redColor()
                     radioButton.highlightColor = UIColor.blueColor()
                     radioButton.indicatorColor = UIColor.greenColor()
-                    radioButton.borderColor = UIColor.purpleColor()
+                    radioButton.borderColorNotSelected = UIColor.purpleColor()
+                    radioButton.borderColorSelected = UIColor.blueColor()
                     radioButton.borderWidth = 4
                     radioButton.buttonRadius = 14
                     radioButton.indicatorRadius = 7
@@ -135,7 +137,9 @@ class WRadioButtonSpec: QuickSpec {
                     expect(radioButton.buttonColor) == UIColor.redColor()
                     expect(radioButton.highlightColor) == UIColor.blueColor()
                     expect(radioButton.indicatorColor) == UIColor.greenColor()
-                    expect(radioButton.borderColor) == UIColor.purpleColor()
+                    expect(radioButton.borderColorNotSelected) == UIColor.purpleColor()
+                    expect(radioButton.borderColorSelected) == UIColor.blueColor()
+                    expect(radioButton.radioCircle.layer.borderColor) == UIColor.blueColor().CGColor
                     expect(radioButton.borderWidth) == 4
                     expect(radioButton.buttonRadius) == 14
                     expect(radioButton.indicatorRadius) == 7


### PR DESCRIPTION
Description
---
In order to support the changes requested in MOBILE-2521, we need the ability to have a different border color for when the radio button is selected and when it is not.

What Was Changed
---
* Changed `borderColor` to now be two vars, `borderColorNotSelected` and `borderColorSelected`. 
* Added a method `updateUISelectedChanged` that updates the border color during setup and `selected`'s `didSet`.
* Added/refactored unit tests.

Testing
---
- [x] Unit tests pass.
- [x] Can be tested alongside the iOS compliment PR. 

---

Please Review: @Workiva/mobile  
