### PR TITLE
MOBILE-2525: Add Accessibility ID's for Functional Tests

### DIFF
--- a/Source/WActionSheet.swift
+++ b/Source/WActionSheet.swift
@@ -402,6 +402,7 @@ public class WActionSheetVC<ActionDataType>: WBaseActionSheet<ActionDataType>, W
         tableView.bounces = false
         tableView.allowsMultipleSelection = false
         tableView.separatorStyle = .None
+        tableView.accessibilityIdentifier = "actionSheetTableView"
 
         tableView.registerClass(WHeaderView.self, forHeaderFooterViewReuseIdentifier: HEADER_VIEW)
         tableView.registerClass(WTableViewCell<ActionDataType>.self, forCellReuseIdentifier: ACTION_CELL)

--- a/Source/WPagingSelectorVC.swift
+++ b/Source/WPagingSelectorVC.swift
@@ -229,6 +229,7 @@ public class WPagingSelectorControl: UIControl {
         scrollView.showsVerticalScrollIndicator = false
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.scrollEnabled = true
+        accessibilityIdentifier = "pagingSelectorControl"
 
         addSubview(scrollView)
         scrollView.snp_makeConstraints { (make) in


### PR DESCRIPTION
Description
---
We needed accessibility ID's on some mobile kit components to improve reliability of functional tests in our Wdesk app

What Was Changed
---
Added accessibilityIdentifiers to both action sheet tables and paging selector controls
- Paging selector control ID isn't used yet but can be utilized in future tests/improvements

Testing
---
Verify that MOBILE-2525 in Wdesk repo is passing using the action sheet accessibility ID

---

Please Review: @Workiva/mobile  
