### PR TITLE
MOBILE-2585: Create Square User Logo

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - SDWebImage/Core (= 4.0.0)
   - SDWebImage/Core (4.0.0)
   - SnapKit (3.2.0)
-  - WMobileKit (3.0.0):
+  - WMobileKit (4.0.0):
     - CryptoSwift (= 0.6.3)
     - SDWebImage (= 4.0.0)
     - SnapKit (= 3.2.0)
@@ -20,7 +20,7 @@ SPEC CHECKSUMS:
   CryptoSwift: 623f81faf4bc34caf78b792f8625fda9fc309abd
   SDWebImage: 76a6348bdc74eb5a55dd08a091ef298e56b55e41
   SnapKit: 1ca44df72cfa543218d177cb8aab029d10d86ea7
-  WMobileKit: 2f5174340e3259c1708895ade66a4dd3b2c223ca
+  WMobileKit: 3d347a02b19670acc77476d781fad5711fcfb51f
 
 PODFILE CHECKSUM: fb0ddbcd40ed7b9c9487bbb0e366869765e5df23
 

--- a/Example/WMobileKitExample/UserLogoViewExamplesVC.swift
+++ b/Example/WMobileKitExample/UserLogoViewExamplesVC.swift
@@ -259,7 +259,7 @@ open class UserLogoViewExamplesVC: WSideMenuContentVC {
         userLogo11.lineWidth = 2
         scrollView.addSubview(userLogo11)
         userLogo11.snp.makeConstraints { (make) in
-            make.centerX.equalTo(view)
+            make.centerX.equalTo(userLogo5)
             make.top.equalTo(userLogoLabel5.snp.bottom).offset(verticalSpacing)
             make.width.equalTo(70)
             make.height.equalTo(70)
@@ -272,6 +272,29 @@ open class UserLogoViewExamplesVC: WSideMenuContentVC {
         userLogoLabel11.snp.makeConstraints { (make) in
             make.top.equalTo(userLogo11.snp.bottom)
             make.centerX.equalTo(userLogo11)
+            make.height.equalTo(20)
+        }
+
+        let userLogo12 = WUserLogoView(name: name11)
+        userLogo12.initialsLimit = 2
+        userLogo12.imageURL = "https://avatars0.githubusercontent.com/u/1087529?v=3&s=200"
+        userLogo12.lineWidth = 2
+        userLogo12.shape = .Square
+        scrollView.addSubview(userLogo12)
+        userLogo12.snp.makeConstraints { (make) in
+            make.centerX.equalTo(userLogo10)
+            make.top.equalTo(userLogoLabel5.snp.bottom).offset(verticalSpacing)
+            make.width.equalTo(70)
+            make.height.equalTo(70)
+        }
+
+        let userLogoLabel12 = UILabel()
+        scrollView.addSubview(userLogoLabel12)
+        userLogoLabel12.text = userLogo11.name
+        userLogoLabel12.textAlignment = .center
+        userLogoLabel12.snp.makeConstraints { (make) in
+            make.top.equalTo(userLogo12.snp.bottom)
+            make.centerX.equalTo(userLogo12)
             make.height.equalTo(20)
         }
 

--- a/Example/WMobileKitExample/UserLogoViewExamplesVC.swift
+++ b/Example/WMobileKitExample/UserLogoViewExamplesVC.swift
@@ -69,6 +69,7 @@ open class UserLogoViewExamplesVC: WSideMenuContentVC {
 
         let userLogo2 = WUserLogoView(name: name2)
         scrollView.addSubview(userLogo2)
+        userLogo2.type = .Filled
         userLogo2.snp.makeConstraints { (make) in
             make.centerX.equalTo(userLogo)
             make.top.equalTo(userLogoLabel.snp.bottom).offset(verticalSpacing)
@@ -89,6 +90,7 @@ open class UserLogoViewExamplesVC: WSideMenuContentVC {
 
         let userLogo3 = WUserLogoView(name: name3)
         scrollView.addSubview(userLogo3)
+        userLogo3.shape = .Square
         userLogo3.snp.makeConstraints { (make) in
             make.centerX.equalTo(userLogo)
             make.top.equalTo(userLogo2.snp.bottom).offset(30)
@@ -109,7 +111,7 @@ open class UserLogoViewExamplesVC: WSideMenuContentVC {
 
         let userLogo4 = WUserLogoView(name: name4)
         userLogo4.initialsLimit = 2
-        userLogo4.initials = "AS"
+        userLogo4.type = .Filled
         scrollView.addSubview(userLogo4)
         userLogo4.snp.makeConstraints { (make) in
             make.centerX.equalTo(userLogo)
@@ -190,6 +192,8 @@ open class UserLogoViewExamplesVC: WSideMenuContentVC {
 
         let userLogo8 = WUserLogoView(name: name8)
         userLogo8.initialsLimit = 1
+        userLogo8.shape = .Square
+        userLogo8.type = .Filled
         scrollView.addSubview(userLogo8)
         userLogo8.snp.makeConstraints { (make) in
             make.centerX.equalTo(userLogo6)
@@ -242,6 +246,7 @@ open class UserLogoViewExamplesVC: WSideMenuContentVC {
         scrollView.addSubview(userLogoLabel10)
         userLogoLabel10.text = userLogo10.name
         userLogoLabel10.textAlignment = .center
+        userLogo10.initials = "AS"
         userLogoLabel10.snp.makeConstraints { (make) in
             make.top.equalTo(userLogo10.snp.bottom)
             make.centerX.equalTo(userLogo10)

--- a/Source/WUserLogoView.swift
+++ b/Source/WUserLogoView.swift
@@ -190,15 +190,17 @@ open class WUserLogoView: UIView {
 
         initialsLabel.attributedText = attributedString
         initialsLabel.textAlignment = NSTextAlignment.center
-        initialsLabel.font = UIFont.systemFont(ofSize: frame.width / 2.5)
         initialsLabel.adjustsFontSizeToFitWidth = true
         switch type {
         case .Outline:
             initialsLabel.textColor = mappedColor
+            initialsLabel.font = UIFont.systemFont(ofSize: frame.width / 2.5)
         case .Filled:
             initialsLabel.textColor = UIColor.white
+            initialsLabel.font = UIFont.boldSystemFont(ofSize: frame.width / 2.5)
         default:
             initialsLabel.textColor = mappedColor
+            initialsLabel.font = UIFont.systemFont(ofSize: frame.width / 2.5)
         }
         bringSubview(toFront: initialsLabel)
     }

--- a/Source/WUserLogoView.swift
+++ b/Source/WUserLogoView.swift
@@ -36,7 +36,7 @@ open class WUserLogoView: UIView {
         }
     }
     open var initialsLabel = UILabel()
-    internal var circleLayer = CAShapeLayer()
+    internal var shapeLayer = CAShapeLayer()
     internal var profileImageView = UIImageView()
 
     internal var mappedColor = UIColor.clear
@@ -139,7 +139,7 @@ open class WUserLogoView: UIView {
         addSubview(initialsLabel)
         addSubview(profileImageView)
 
-        layer.addSublayer(circleLayer)
+        layer.addSublayer(shapeLayer)
     }
 
     fileprivate func setupUIMainThread() {
@@ -198,9 +198,6 @@ open class WUserLogoView: UIView {
         case .Filled:
             initialsLabel.textColor = UIColor.white
             initialsLabel.font = UIFont.boldSystemFont(ofSize: frame.width / 2.5)
-        default:
-            initialsLabel.textColor = mappedColor
-            initialsLabel.font = UIFont.systemFont(ofSize: frame.width / 2.5)
         }
         bringSubview(toFront: initialsLabel)
     }
@@ -225,21 +222,17 @@ open class WUserLogoView: UIView {
             path = UIBezierPath(arcCenter: center, radius: frame.width / 2 - 1, startAngle: 0, endAngle: CGFloat(Double.pi * 2), clockwise: true)
         case .Square:
             path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: frame.width, height: frame.height), cornerRadius: cornerRadius)
-        default:
-            path = UIBezierPath(arcCenter: center, radius: frame.width / 2 - 1, startAngle: 0, endAngle: CGFloat(Double.pi * 2), clockwise: true)
         }
 
-        circleLayer.path = path.cgPath
+        shapeLayer.path = path.cgPath
         switch type {
         case .Outline:
-            circleLayer.fillColor = UIColor.clear.cgColor
+            shapeLayer.fillColor = UIColor.clear.cgColor
         case.Filled:
-            circleLayer.fillColor = mappedColor.cgColor
-        default:
-            circleLayer.fillColor = UIColor.clear.cgColor
+            shapeLayer.fillColor = mappedColor.cgColor
         }
-        circleLayer.lineWidth = lineWidth
-        circleLayer.strokeColor = mappedColor.cgColor
+        shapeLayer.lineWidth = lineWidth
+        shapeLayer.strokeColor = mappedColor.cgColor
     }
 
     fileprivate func updateMappedColor() {

--- a/Source/WUserLogoView.swift
+++ b/Source/WUserLogoView.swift
@@ -207,7 +207,12 @@ open class WUserLogoView: UIView {
             initialsLabel.isHidden = true
             profileImageView.isHidden = false
 
-            profileImageView.layer.cornerRadius = profileImageView.frame.width / 2
+            switch shape {
+            case .Circle:
+                profileImageView.layer.cornerRadius = profileImageView.frame.width / 2
+            case .Square:
+                profileImageView.layer.cornerRadius = cornerRadius
+            }
             profileImageView.clipsToBounds = true
             profileImageView.contentMode = .scaleAspectFill
         }

--- a/Source/WUserLogoView.swift
+++ b/Source/WUserLogoView.swift
@@ -21,6 +21,14 @@ import UIKit
 import CryptoSwift
 import SDWebImage
 
+public enum Shape {
+    case Circle, Square
+}
+
+public enum Type {
+    case Outline, Filled
+}
+
 open class WUserLogoView: UIView {
     open var initialsLimit = 3 {
         didSet {
@@ -53,6 +61,24 @@ open class WUserLogoView: UIView {
     }
 
     open var lineWidth: CGFloat = 1.0 {
+        didSet {
+            setupUI()
+        }
+    }
+
+    open var shape: Shape = .Circle {
+        didSet {
+            setupUI()
+        }
+    }
+
+    open var type: Type = .Outline {
+        didSet {
+            setupUI()
+        }
+    }
+
+    open var cornerRadius: CGFloat = 3 {
         didSet {
             setupUI()
         }
@@ -151,7 +177,7 @@ open class WUserLogoView: UIView {
             setupImage()
         }
 
-        setupCircle()
+        setupShape()
     }
 
     fileprivate func setupInitials() {
@@ -166,7 +192,15 @@ open class WUserLogoView: UIView {
         initialsLabel.textAlignment = NSTextAlignment.center
         initialsLabel.font = UIFont.systemFont(ofSize: frame.width / 2.5)
         initialsLabel.adjustsFontSizeToFitWidth = true
-        initialsLabel.textColor = mappedColor
+        switch type {
+        case .Outline:
+            initialsLabel.textColor = mappedColor
+        case .Filled:
+            initialsLabel.textColor = UIColor.white
+        default:
+            initialsLabel.textColor = mappedColor
+        }
+        bringSubview(toFront: initialsLabel)
     }
 
     fileprivate func setupImage() {
@@ -180,12 +214,28 @@ open class WUserLogoView: UIView {
         }
     }
 
-    fileprivate func setupCircle() {
+    fileprivate func setupShape() {
         let center = CGPoint(x: frame.width / 2, y: frame.height / 2)
-        let path = UIBezierPath(arcCenter: center, radius: frame.width / 2 - 1, startAngle: 0, endAngle: CGFloat(Double.pi * 2), clockwise: true)
+        var path: UIBezierPath!
+
+        switch shape {
+        case .Circle:
+            path = UIBezierPath(arcCenter: center, radius: frame.width / 2 - 1, startAngle: 0, endAngle: CGFloat(Double.pi * 2), clockwise: true)
+        case .Square:
+            path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: frame.width, height: frame.height), cornerRadius: cornerRadius)
+        default:
+            path = UIBezierPath(arcCenter: center, radius: frame.width / 2 - 1, startAngle: 0, endAngle: CGFloat(Double.pi * 2), clockwise: true)
+        }
 
         circleLayer.path = path.cgPath
-        circleLayer.fillColor = UIColor.clear.cgColor
+        switch type {
+        case .Outline:
+            circleLayer.fillColor = UIColor.clear.cgColor
+        case.Filled:
+            circleLayer.fillColor = mappedColor.cgColor
+        default:
+            circleLayer.fillColor = UIColor.clear.cgColor
+        }
         circleLayer.lineWidth = lineWidth
         circleLayer.strokeColor = mappedColor.cgColor
     }

--- a/Tests/WUserLogoViewTests.swift
+++ b/Tests/WUserLogoViewTests.swift
@@ -287,6 +287,17 @@ class WUserLogoViewTests: QuickSpec {
                     expect(userLogoView.initialsLabel.textColor) == UIColor.white
                     expect(userLogoView.shapeLayer.fillColor) == userLogoView.mappedColor.cgColor
                 }
+
+                it("should set correct corner radius") {
+                    userLogoView.shape = .Square
+                    userLogoView.imageURL = "https://avatars0.githubusercontent.com/u/1087529?v=3&s=200"
+
+                    let cornerRadius: CGFloat = 5
+
+                    userLogoView.cornerRadius = cornerRadius
+
+                    expect(userLogoView.profileImageView.layer.cornerRadius) == cornerRadius
+                }
             }
         }
     }

--- a/Tests/WUserLogoViewTests.swift
+++ b/Tests/WUserLogoViewTests.swift
@@ -251,6 +251,43 @@ class WUserLogoViewTests: QuickSpec {
                     expect(color11).to(equal(color12))
                 }
             }
+
+            describe("type and shape") {
+                let frame = CGRect(x: 0, y: 0, width: 20, height: 20)
+                let center = CGPoint(x: frame.width / 2, y: frame.height / 2)
+
+                beforeEach({
+                    userLogoView = WUserLogoView()
+                    userLogoView.frame = frame
+                    userLogoView.name = name1
+                })
+
+                it("should use default values") {
+                    expect(userLogoView.type) == Type.Outline
+                    expect(userLogoView.shape) == Shape.Circle
+                    expect(userLogoView.cornerRadius) == 3
+                }
+
+                it("should create the correct shape") {
+                    userLogoView.shape = .Circle
+                    expect(userLogoView.shapeLayer.path) == UIBezierPath(arcCenter: center, radius: frame.width / 2 - 1, startAngle: 0, endAngle: CGFloat(Double.pi * 2), clockwise: true).cgPath
+
+                    userLogoView.shape = .Square
+                    expect(userLogoView.shapeLayer.path) == UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: frame.width, height: frame.height), cornerRadius: userLogoView.cornerRadius).cgPath
+                }
+
+                it("should set fill and font for correct type") {
+                    userLogoView.type = .Outline
+
+                    expect(userLogoView.initialsLabel.textColor) == userLogoView.mappedColor
+                    expect(userLogoView.shapeLayer.fillColor) == UIColor.clear.cgColor
+
+                    userLogoView.type = .Filled
+
+                    expect(userLogoView.initialsLabel.textColor) == UIColor.white
+                    expect(userLogoView.shapeLayer.fillColor) == userLogoView.mappedColor.cgColor
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Description
---
Add square version of User Logo component to MobileKit

Acceptance Criteria:
----
1. Component should be customizable
2. Utilizes existing User Logo

What Was Changed
---
Added two properties to WUserLogoView:
1. Type
   - .Outline
      - Default value, only draws outline of shape, font matches color of mapped color
   - .Filled
      - Will fill in the whole shape, change font to a bolded white color
      - Also with a customizable corner radius
2. Shape
   - .Circle
      - Default value, draws a circle like normal
   - .Square
      - Draws a square with rounded corners based on the cornerRadius property of WUserLogo, which has a default value of 3.0

Testing
---
- Ensure unit tests pass
- Look at example app and ensure all combinations of shapes, types, and images vs no images are represented and are fully customizable

---

Please Review: @Workiva/mobile  
