### PR TITLE
MOBILE-2612: Fix incompatibilities with Material Library

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,11 +1,15 @@
 PODS:
   - CryptoSwift (0.6.3)
+  - Material (2.6.3):
+    - Material/Core (= 2.6.3)
+  - Material/Core (2.6.3)
   - SDWebImage (4.0.0):
     - SDWebImage/Core (= 4.0.0)
   - SDWebImage/Core (4.0.0)
   - SnapKit (3.2.0)
-  - WMobileKit (4.0.0):
+  - WMobileKit (4.1.0):
     - CryptoSwift (= 0.6.3)
+    - Material (= 2.6.3)
     - SDWebImage (= 4.0.0)
     - SnapKit (= 3.2.0)
 
@@ -18,9 +22,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CryptoSwift: 623f81faf4bc34caf78b792f8625fda9fc309abd
+  Material: af607a7ec0e9978ef85cf189a3d8ceeeb650400f
   SDWebImage: 76a6348bdc74eb5a55dd08a091ef298e56b55e41
   SnapKit: 1ca44df72cfa543218d177cb8aab029d10d86ea7
-  WMobileKit: 3d347a02b19670acc77476d781fad5711fcfb51f
+  WMobileKit: cb091a1f14ec372fd1217a0ff91d40a68a7091e3
 
 PODFILE CHECKSUM: fb0ddbcd40ed7b9c9487bbb0e366869765e5df23
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem "cocoapods", "1.2.0.beta.1"
+gem "cocoapods", "1.2.1"
 gem "xcov", "1.1.2"
 gem "ocunit2junit"

--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,7 @@ def common_pods
   pod 'SnapKit', '3.2.0'
   pod 'CryptoSwift', '0.6.3'
   pod 'SDWebImage', '4.0.0'
+  pod 'Material', '2.6.3' #https://github.com/CosmicMind/Material
 end
 
 target 'WMobileKit' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,8 @@
 PODS:
   - CryptoSwift (0.6.3)
+  - Material (2.6.3):
+    - Material/Core (= 2.6.3)
+  - Material/Core (2.6.3)
   - Nimble (6.0.1)
   - Quick (1.1.0)
   - SDWebImage (4.0.0):
@@ -9,6 +12,7 @@ PODS:
 
 DEPENDENCIES:
   - CryptoSwift (= 0.6.3)
+  - Material (= 2.6.3)
   - Nimble (= 6.0.1)
   - Quick (= 1.1.0)
   - SDWebImage (= 4.0.0)
@@ -16,11 +20,12 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   CryptoSwift: 623f81faf4bc34caf78b792f8625fda9fc309abd
+  Material: af607a7ec0e9978ef85cf189a3d8ceeeb650400f
   Nimble: 1527fd1bd2b4cf0636251a36bc8ab37e81da8347
   Quick: dafc587e21eed9f4cab3249b9f9015b0b7a7f71d
   SDWebImage: 76a6348bdc74eb5a55dd08a091ef298e56b55e41
   SnapKit: 1ca44df72cfa543218d177cb8aab029d10d86ea7
 
-PODFILE CHECKSUM: 99ce8942b5fdd2efd6176cf6d0072e2f868e556b
+PODFILE CHECKSUM: 5cfc0151f44d2078794ca0e1f23605a79cea90aa
 
 COCOAPODS: 1.2.0.beta.1

--- a/Source/WBadge.swift
+++ b/Source/WBadge.swift
@@ -46,7 +46,7 @@ open class WBadge: UIView {
         }
     }
     
-    open var borderWidth: CGFloat = 0 {
+    open var badgeBorderWidth: CGFloat = 0 {
         didSet {
             setupUI()
         }
@@ -191,8 +191,8 @@ open class WBadge: UIView {
         borderView.snp.remakeConstraints { (make) in
             make.centerX.equalTo(badgeView)
             make.centerY.equalTo(badgeView)
-            make.width.equalTo(badgeView.snp.width).offset(borderWidth)
-            make.height.equalTo(badgeView.snp.height).offset(borderWidth)
+            make.width.equalTo(badgeView.snp.width).offset(badgeBorderWidth)
+            make.height.equalTo(badgeView.snp.height).offset(badgeBorderWidth)
         }
         
         countLabel.snp.remakeConstraints { (make) in
@@ -223,7 +223,7 @@ open class WBadge: UIView {
     }
 
     internal func sizeForBadge() -> CGSize {
-        return CGSize(width: labelSize.width + widthPadding + borderWidth + (shouldShowValue() ? 0 : 1), height: labelSize.height + heightPadding + borderWidth)
+        return CGSize(width: labelSize.width + widthPadding + badgeBorderWidth + (shouldShowValue() ? 0 : 1), height: labelSize.height + heightPadding + badgeBorderWidth)
     }
 
     internal func setBadgeCount(_ count: Int) {

--- a/Source/WBanner.swift
+++ b/Source/WBanner.swift
@@ -60,7 +60,7 @@ open class WBannerView: UIView {
     open var hideOptions: WBannerHideOptions = .dismissesAfterTime
     open var placement: WBannerPlacementOptions = .bottom
     open var animationDuration = BANNER_DEFAULT_ANIMATION_DURATION
-    open var height = BANNER_DEFAULT_HEIGHT
+    open var bannerHeight = BANNER_DEFAULT_HEIGHT
     open var sidePadding: CGFloat = 0
 
     open var titleMessage = "" {
@@ -295,7 +295,7 @@ open class WBannerView: UIView {
 
         rootView!.addSubview(self)
         snp.remakeConstraints { (make) in
-            make.height.equalTo(height)
+            make.height.equalTo(bannerHeight)
             make.left.equalTo(rootView!).offset(sidePadding)
             make.right.equalTo(rootView!).offset(-sidePadding)
 
@@ -311,7 +311,7 @@ open class WBannerView: UIView {
         rootView!.layoutIfNeeded()
 
         snp.remakeConstraints { (make) in
-            make.height.equalTo(height)
+            make.height.equalTo(bannerHeight)
 
             if (placement == .bottom) {
                 make.bottom.equalTo(rootView!)
@@ -344,7 +344,7 @@ open class WBannerView: UIView {
         if isVisible() {
             //animate out
             snp.remakeConstraints{ (make) in
-                make.height.equalTo(height)
+                make.height.equalTo(bannerHeight)
                 make.left.equalTo(rootView!).offset(sidePadding)
                 make.right.equalTo(rootView!).offset(-sidePadding)
 

--- a/Tests/WBadgeTests.swift
+++ b/Tests/WBadgeTests.swift
@@ -53,7 +53,7 @@ class WBadgeSpec: QuickSpec {
                 expect(badge.badgeColor) == UIColor(hex: 0x0094FF)
                 expect(badge.countColor) == UIColor.white
                 expect(badge.borderColor) == UIColor.clear
-                expect(badge.borderWidth) == 0
+                expect(badge.badgeBorderWidth) == 0
                 expect(badge.horizontalAlignment) == xAlignment.left
                 expect(badge.verticalAlignment) == yAlignment.top
                 expect(badge.automaticallyHide) == true
@@ -107,7 +107,7 @@ class WBadgeSpec: QuickSpec {
                     badge.badgeColor = UIColor.brown
                     badge.countColor = UIColor.darkGray
                     badge.borderColor = UIColor.white
-                    badge.borderWidth = 2
+                    badge.badgeBorderWidth = 2
                     badge.horizontalAlignment = xAlignment.right
                     badge.horizontalAlignment = xAlignment.center
                     badge.verticalAlignment = yAlignment.bottom
@@ -126,7 +126,7 @@ class WBadgeSpec: QuickSpec {
                     expect(badge.badgeColor) == UIColor.brown
                     expect(badge.countColor) == UIColor.darkGray
                     expect(badge.borderColor) == UIColor.white
-                    expect(badge.borderWidth) == 2
+                    expect(badge.badgeBorderWidth) == 2
                     expect(badge.horizontalAlignment) == xAlignment.center
                     expect(badge.verticalAlignment) == yAlignment.center
                     expect(badge.automaticallyHide) == false

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -22,4 +22,5 @@ Pod::Spec.new do |s|
   s.dependency 'SnapKit', '3.2.0'
   s.dependency 'CryptoSwift', '0.6.3'
   s.dependency 'SDWebImage', '4.0.0'
+  s.dependency 'Material', '2.6.3'
 end

--- a/smithy.sh
+++ b/smithy.sh
@@ -86,7 +86,7 @@ clean_previous_build
 
 print_heading "Generating code coverage report"
 bundle exec xcov -m 90 -w WMobileKit.xcworkspace -s WMobileKit -o xcov  \
-    --exclude_targets 'SDWebImage.framework, Nimble.framework, SnapKit.framework, CryptoSwift.framework, Quick.framework'
+    --exclude_targets 'SDWebImage.framework, Nimble.framework, SnapKit.framework, CryptoSwift.framework, Quick.framework, Material.framework'
 
 # If code coverage is not at least the minimum, stop here.
 if [ $? -ne 0 ]; then

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -2,6 +2,7 @@ language: python
 
 runner_image: drydock-prod.workiva.net/workiva/smithy-runner:127520
 before_install:
+  - bundle update
   - bundle install --path ~/.gem
   - rbenv rehash
 


### PR DESCRIPTION
Description
---
w-mobile-kit is currently hitting some collisions with the naming in Material library. This should be fixes and the library included to avoid future issues.

What Was Changed
---
- Fixed a few naming collisions with certain extensions

Testing
---
1. Verify no functionality was changed
2. Unit tests pass. 

---

Please Review: @Workiva/mobile  
