### PR TITLE
MOBILE-2615: Increase Mobile Kit flexibility

### DIFF
--- a/Source/WLoadingModal.swift
+++ b/Source/WLoadingModal.swift
@@ -130,7 +130,7 @@ open class WLoadingModal: UIView {
         commonInit()
     }
 
-    fileprivate func commonInit() {
+    open func commonInit() {
         backgroundColor = WThemeManager.sharedInstance.currentTheme.loadingModalBackgroundColor
 
         if (addBlurBackground) {

--- a/Source/WSideMenuVC.swift
+++ b/Source/WSideMenuVC.swift
@@ -310,7 +310,13 @@ open class WSideMenuVC: WSizeVC {
         )
     }
 
+    // Forwarding method call instead of having default parameter value to avoid breaking change
     open func closeSideMenu() {
+        closeSideMenu(completion: nil)
+    }
+
+    // Allow completion block parameter to avoid having to replace the delegate
+    open func closeSideMenu(completion: ((Swift.Void) -> Swift.Void)?) {
         delegate?.sideMenuWillClose?()
         
         leftSideMenuContainerView.snp.remakeConstraints { (make) in
@@ -334,6 +340,8 @@ open class WSideMenuVC: WSizeVC {
                 
                 // Disable the tap outside the drawer to close
                 self.backgroundTapView.isHidden = true
+
+                completion?()
             }
         )
     }


### PR DESCRIPTION
Description
---
It was hard to subclass WLoadingModal and add changes necessary due to private declaration of the `commonInit` method.

The WSideMenuVC can only have one delegate so it was tricky to tap into when the drawer closes fully.

What Was Changed
---
- WLoadingModal's `commonInit` was changed to `open` visibility
- WSideMenuVC's `closeDrawer` method now can accept a completion block called after the animation finishes.

Testing
---
Test in Wdesk iOS PR of `MOBILE-2589, 2615`

---

Please Review: @Workiva/mobile  
