### PR TITLE
MOBILE-2642 Consume smithy-runner v3.6.3

### DIFF
--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,6 +1,6 @@
 language: python
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner:127520
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner:223860
 before_install:
   - bundle update
   - bundle install --path ~/.gem


### PR DESCRIPTION

Pulls Included in Release:
* [BUILDTOOLS-1297 Consume smithy-runner 3.5.5](https://github.com/Workiva/smithy-runner/pull/25)
* [BUILDTOOLS-1297 Consume smithy-runner v3.6.2](https://github.com/Workiva/smithy-runner/pull/30)
* [BUILDTOOLS-1574 Upgrade smithy-builder](https://github.com/Workiva/smithy-runner/pull/32)

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5487653855166464/logs/)