### PR TITLE
BUILDTOOLS-1575 Consume smithy-runner v3.6.4

### DIFF
--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,6 +1,6 @@
 language: python
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner:127520
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner:224702
 before_install:
   - bundle update
   - bundle install --path ~/.gem


### PR DESCRIPTION

Pulls Included in Release:
* [BUILDTOOLS-1566 Consume smithy-builder v3.8.1](https://github.com/Workiva/smithy-runner/pull/35)

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5487653855166464/logs/)