### PR TITLE
MOBILE-2642 Release w-mobile-kit 5.1.0

### DIFF
--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.2</string>
+	<string>5.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.2</string>
+	<string>5.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '5.0.2'
+  s.version          = '5.1.0'
   s.summary          = 'Swift library containing various custom UI components to provide functionality outside of the default libraries.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/Workiva/w-mobile-kit'


### PR DESCRIPTION

Pulls Included in Release:
* [MOBILE-2656: Xcode 9/Swift 3.2](https://github.com/Workiva/w-mobile-kit/pull/149)
* [[Update Readme] Update readme with links to source code.](https://github.com/Workiva/w-mobile-kit/pull/151)


Requested by: @jamesromo-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w-mobile-kit/compare/5.0.2...Workiva:release_w-mobile-kit_5_1_0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w-mobile-kit/compare/5.0.2...5.1.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5659090173820928/logs/)