### PR TITLE
SEC-17380 - Bumping rubyzip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     retriable (3.1.1)
     rouge (2.0.7)
     ruby-macho (1.1.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     security (0.1.3)
     signet (0.7.3)
       addressable (~> 2.3)


### PR DESCRIPTION
**Problem:** There was a vulnerability found in `rubyzip <=1.2.1`.

https://nvd.nist.gov/vuln/detail/CVE-2018-1000544

**Solution:** Bump to `rubyzip >=1.2.2`.

@jamesromo-wf @jordanross-wf 