### PR TITLE
MOBILE-2709 Bump Version to 5.1.3 for Latest Release

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - SDWebImage/Core (= 4.0.0)
   - SDWebImage/Core (4.0.0)
   - SnapKit (3.2.0)
-  - WMobileKit (5.1.1):
+  - WMobileKit (5.1.3):
     - SDWebImage (= 4.0.0)
     - SnapKit (= 3.2.0)
 
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   SDWebImage: 76a6348bdc74eb5a55dd08a091ef298e56b55e41
   SnapKit: 1ca44df72cfa543218d177cb8aab029d10d86ea7
-  WMobileKit: d2c6d75ebf8af0e8f0b91644441cdcd28ee2ceb6
+  WMobileKit: 2908b8bd6bd6643bfee307ee3211d622999c2dd0
 
 PODFILE CHECKSUM: 11fa404a0cf37eea8d730e11ab88e15c604e818b
 

--- a/Example/WMobileKitExample/Info.plist
+++ b/Example/WMobileKitExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.1.1</string>
+	<string>5.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.1.1</string>
+	<string>5.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WMobileKit.podspec
+++ b/WMobileKit.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WMobileKit'
-  s.version          = '5.1.1'
+  s.version          = '5.1.3'
   s.summary          = 'Swift library containing various custom UI components to provide functionality outside of the default libraries.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/Workiva/w-mobile-kit'


### PR DESCRIPTION
Description
---
The last release went out with the wrong versions specified

What Was Changed
---
Bumped version to 5.1.3

Acceptance Criteria
---
Version is bumped to 5.1.3

Testing Instructions
---
N/A

Merge Checklist
---
- [ ] Author of commit is not a reviewer
- [ ] CR +1
- [ ] +10 (includes code review and pulling in the code/testing)
- [ ] bundle exec pod lib lint WMobileKit.podspec --allow-warnings passes
- [ ] Security review if applicable
- [ ] Bump the WMobileKit.podspec, Source/Info.plist, and Example/WMobileKitExample/Info.plist
using ```version_bump.sh```according to semantic versioning.

Example: (5.1.0 is the old version 5.1.1 is the new version)
```ruby
./version_bump.sh 5.1.0 5.1.1
```

---
Please Review: @Workiva/mobile  
